### PR TITLE
feat: Sprint 3 — pharmacy dashboard, order management, delivery preference

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -41,4 +41,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: .
-          exclude_assets: '.github,node_modules,tests,scripts,js/env.js'
+          exclude_assets: '.github,node_modules,tests,scripts'
+          force_orphan: true

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,4 +1,4 @@
-name: Deploy to GitHub Pages (Dev)
+name: Run Tests (Dev)
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - master
 
 jobs:
-  deploy:
+  test:
     runs-on: ubuntu-latest
 
     steps:
@@ -21,25 +21,5 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Inject dev Firebase config
-        run: |
-          cat > js/env.js << EOF
-          window.__env = {
-            FIREBASE_API_KEY:             "${{ secrets.DEV_FIREBASE_API_KEY }}",
-            FIREBASE_AUTH_DOMAIN:         "${{ secrets.DEV_FIREBASE_AUTH_DOMAIN }}",
-            FIREBASE_PROJECT_ID:          "${{ secrets.DEV_FIREBASE_PROJECT_ID }}",
-            FIREBASE_MESSAGING_SENDER_ID: "${{ secrets.DEV_FIREBASE_MESSAGING_SENDER_ID }}",
-            FIREBASE_APP_ID:              "${{ secrets.DEV_FIREBASE_APP_ID }}"
-          };
-          EOF
-
       - name: Run tests
         run: npm test
-
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: .
-          exclude_assets: '.github,node_modules,tests,scripts'
-          force_orphan: true

--- a/README.md
+++ b/README.md
@@ -2,11 +2,6 @@
 
 A web application for people living with diabetes — combining a **medicine restock request portal** with a **peer support community feed**.
 
-*Check Out the Live Sites Using the Links Below*:
-
-[![Dev](https://img.shields.io/badge/Dev-GitHub%20Pages-222?style=flat&logo=github)](https://jeffin03.github.io/ShareCare)
-[![Prod](https://img.shields.io/badge/Prod-Vercel-000?style=flat&logo=vercel)](https://share-care-bice.vercel.app/)
-
 ---
 
 ## Abstract

--- a/auth/login.html
+++ b/auth/login.html
@@ -1,298 +1,128 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ShareCare — Log In</title>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/remixicon/4.6.0/remixicon.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="../assets/styles.css">
+  <link rel="stylesheet" href="../assets/style.css">
   <style>
-    body {
-      display: flex;
-      flex-direction: column;
-      min-height: 100vh;
-    }
-
-    .auth-page {
-      flex: 1;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: 48px 24px;
-      background: var(--bg);
-    }
-
-    .auth-split {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      max-width: 900px;
-      width: 100%;
-      background: var(--card);
-      border-radius: var(--r-xl);
-      overflow: hidden;
-      box-shadow: var(--shadow-md);
-      border: 1px solid var(--border-light);
-    }
-
-    .auth-panel {
-      padding: 52px 48px;
-    }
-
-    .auth-visual {
-      background: linear-gradient(145deg, var(--primary) 0%, var(--primary-dark) 100%);
-      padding: 52px 40px;
-      display: flex;
-      flex-direction: column;
-      justify-content: space-between;
-      position: relative;
-      overflow: hidden;
-    }
-
-    .auth-visual::before {
-      content: '';
-      position: absolute;
-      width: 300px;
-      height: 300px;
-      background: rgba(255, 255, 255, 0.06);
-      border-radius: 50%;
-      top: -80px;
-      right: -80px;
-    }
-
-    .auth-visual::after {
-      content: '';
-      position: absolute;
-      width: 200px;
-      height: 200px;
-      background: rgba(255, 255, 255, 0.04);
-      border-radius: 50%;
-      bottom: -40px;
-      left: -40px;
-    }
-
-    .visual-top .logo-v {
-      font-family: 'DM Serif Display', serif;
-      font-size: 1.5rem;
-      color: white;
-      display: flex;
-      align-items: center;
-      gap: 10px;
-      margin-bottom: 40px;
-    }
-
-    .visual-top .logo-v i {
-      color: rgba(255, 255, 255, 0.7);
-      font-size: 1.6rem;
-    }
-
-    .visual-quote {
-      font-family: 'DM Serif Display', serif;
-      font-style: italic;
-      font-size: 1.4rem;
-      color: white;
-      line-height: 1.4;
-      margin-bottom: 12px;
-    }
-
-    .visual-sub {
-      font-size: 0.85rem;
-      color: rgba(255, 255, 255, 0.65);
-    }
-
-    .visual-dots {
-      display: flex;
-      gap: 6px;
-      margin-top: auto;
-    }
-
-    .dot {
-      width: 8px;
-      height: 8px;
-      border-radius: 50%;
-      background: rgba(255, 255, 255, 0.3);
-    }
-
-    .dot.active {
-      background: white;
-      width: 24px;
-    }
-
-    .auth-header {
-      margin-bottom: 32px;
-    }
-
-    .auth-header h2 {
-      margin-bottom: 6px;
-      color: var(--text);
-    }
-
-    .auth-header p {
-      font-size: 0.88rem;
-    }
-
-    .btn-submit {
-      width: 100%;
-      padding: 13px;
-      background: var(--primary);
-      color: white;
-      border: none;
-      border-radius: var(--r);
-      font-family: 'DM Sans', sans-serif;
-      font-size: 0.95rem;
-      font-weight: 600;
-      cursor: pointer;
-      margin-top: 8px;
-      transition: all 0.2s;
-      box-shadow: 0 4px 14px rgba(92, 141, 122, 0.3);
-    }
-
-    .btn-submit:hover {
-      background: var(--primary-dark);
-      transform: translateY(-1px);
-    }
-
-    .auth-footer {
-      text-align: center;
-      margin-top: 20px;
-    }
-
-    .auth-footer p {
-      font-size: 0.85rem;
-      color: var(--text-muted);
-    }
-
-    .auth-footer a {
-      color: var(--primary);
-      font-weight: 600;
-      text-decoration: none;
-    }
-
-    .auth-footer a:hover {
-      text-decoration: underline;
-    }
-
-    .guest-link {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      color: var(--text-muted);
-      text-decoration: none;
-      font-size: 0.84rem;
-      font-weight: 500;
-      margin-top: 10px;
-      padding: 8px 18px;
-      border-radius: var(--r-full);
-      border: 1px solid var(--border);
-      transition: all 0.2s;
-    }
-
-    .guest-link:hover {
-      border-color: var(--primary);
-      color: var(--primary);
-    }
+    body{display:flex;min-height:100vh;flex-direction:column;}
+    .auth-wrap{flex:1;display:flex;}
+    .auth-left{width:42%;background:var(--primary);padding:52px 52px;display:flex;flex-direction:column;justify-content:space-between;position:relative;overflow:hidden;}
+    .auth-left::before{content:'';position:absolute;width:500px;height:500px;border-radius:50%;background:rgba(255,255,255,0.05);bottom:-150px;right:-150px;}
+    .auth-left-logo{display:flex;align-items:center;gap:10px;font-family:'DM Serif Display',serif;font-size:22px;color:white;text-decoration:none;}
+    .auth-left-logo i{color:rgba(255,255,255,0.7);}
+    .auth-left-content h2{font-size:36px;color:white;margin-bottom:14px;}
+    .auth-left-content p{font-size:15px;color:rgba(255,255,255,0.75);line-height:1.7;max-width:300px;}
+    .auth-features{list-style:none;display:flex;flex-direction:column;gap:14px;position:relative;z-index:1;}
+    .auth-features li{display:flex;align-items:center;gap:12px;color:rgba(255,255,255,0.85);font-size:14px;}
+    .auth-features li i{width:32px;height:32px;background:rgba(255,255,255,0.12);border-radius:8px;display:flex;align-items:center;justify-content:center;font-size:16px;flex-shrink:0;}
+    .auth-right{flex:1;display:flex;align-items:center;justify-content:center;padding:48px 40px;background:var(--bg);}
+    .auth-card{background:var(--card);border-radius:var(--radius-xl);padding:48px 44px;width:100%;max-width:420px;border:1px solid var(--border-light);box-shadow:var(--shadow-md);}
+    .auth-card h1{font-size:26px;margin-bottom:6px;}
+    .auth-card>p{font-size:14px;color:var(--text-muted);margin-bottom:28px;}
+    .forgot{text-align:right;margin-top:6px;}
+    .forgot a{font-size:13px;color:var(--primary);text-decoration:none;font-weight:500;}
+    .btn-submit{width:100%;padding:14px;background:var(--primary);color:white;border:none;border-radius:var(--radius-md);font-family:'DM Sans',sans-serif;font-size:15px;font-weight:600;cursor:pointer;margin-top:8px;transition:all 0.2s;box-shadow:0 4px 14px rgba(78,140,117,0.28);}
+    .btn-submit:hover{background:var(--primary-dark);transform:translateY(-1px);}
+    .auth-footer{text-align:center;}
+    .auth-footer p{font-size:14px;color:var(--text-muted);margin-bottom:10px;}
+    .auth-footer a{color:var(--primary);font-weight:600;text-decoration:none;}
+    .guest-link{display:inline-flex;align-items:center;gap:6px;font-size:13px;color:var(--text-muted);text-decoration:none;margin-top:8px;transition:color 0.2s;}
+    .guest-link:hover{color:var(--primary);}
+    .error-msg{background:#FEF2F2;border:1px solid #FECACA;border-radius:var(--radius-sm);padding:10px 14px;font-size:13px;color:#991B1B;margin-bottom:16px;display:none;align-items:center;gap:8px;}
   </style>
-  <script src="../js/env.js"></script>
 </head>
-
 <body>
-  <nav class="nav">
-    <a href="../index.html" class="nav-logo"><i class="ri-heart-pulse-fill"></i> ShareCare</a>
-  </nav>
-
-  <div class="auth-page">
-    <div class="auth-split">
-      <!-- Visual panel -->
-      <div class="auth-visual">
-        <div class="visual-top">
-          <div class="logo-v"><i class="ri-heart-pulse-fill"></i> ShareCare</div>
-          <div class="visual-quote">"Managing diabetes is a journey. You don't have to walk it alone."</div>
-          <div class="visual-sub">Join thousands finding support every day</div>
-        </div>
-        <div class="visual-dots">
-          <div class="dot active"></div>
-          <div class="dot"></div>
-          <div class="dot"></div>
-        </div>
+  <div class="auth-wrap">
+    <div class="auth-left">
+      <a href="../index.html" class="auth-left-logo"><i class="ri-heart-pulse-fill"></i> ShareCare</a>
+      <div class="auth-left-content">
+        <h2>Good to have<br>you back.</h2>
+        <p>Log in to manage your medicine requests or connect with the community.</p>
       </div>
-
-      <!-- Form panel -->
-      <div class="auth-panel">
-        <div class="auth-header">
-          <h2>Welcome back</h2>
-          <p>Log in to continue to ShareCare</p>
-        </div>
-
-      <div class="error-msg" id="errorMsg" style="display:none;">
-        <i class="ri-error-warning-line"></i><span id="errorText"></span>
-      </div>
-
-      <form id="loginForm">
-        <div class="form-group">
-          <label class="label">Email address</label>
-          <div class="input-wrap">
-            <i class="ri-mail-line i-left"></i>
-            <input type="email" class="input" id="email" placeholder="name@example.com" required>
+      <ul class="auth-features">
+        <li><i class="ri-medicine-bottle-line"></i> Request medicine restocks from your pharmacy</li>
+        <li><i class="ri-group-line"></i> Share and discover peer experiences</li>
+        <li><i class="ri-shield-check-line"></i> Safe, moderated, peer-support only</li>
+      </ul>
+    </div>
+    <div class="auth-right">
+      <div class="auth-card">
+        <h1>Welcome back</h1>
+        <p>Log in to your ShareCare account</p>
+        <div class="error-msg" id="errorMsg"><i class="ri-error-warning-line"></i><span id="errorText"></span></div>
+        <form id="loginForm">
+          <div class="form-group">
+            <label class="form-label">Email address</label>
+            <div class="input-wrap"><i class="ri-mail-line input-icon"></i>
+              <input type="email" class="form-input has-icon" id="email" placeholder="name@example.com" required>
+            </div>
           </div>
-        </div>
-        <div class="form-group">
-          <label class="label" style="display:flex;justify-content:space-between;">
-            Password
-            <a href="#" style="color:var(--primary);font-weight:500;font-size:0.78rem;">Forgot password?</a>
-          </label>
-          <div class="input-wrap">
-            <i class="ri-lock-2-line i-left"></i>
-            <input type="password" class="input" id="password" placeholder="••••••••">
-            <i class="ri-eye-off-line i-right" onclick="togglePw()"></i>
+          <div class="form-group">
+            <label class="form-label">Password</label>
+            <div class="input-wrap"><i class="ri-lock-2-line input-icon"></i>
+              <input type="password" class="form-input has-icon" id="password" placeholder="••••••••" required>
+            </div>
+            <div class="forgot"><a href="#">Forgot password?</a></div>
           </div>
-        </div>
-        <button type="submit" class="btn-submit" id="submitBtn">Log in</button>
-      </form>
+          <button type="submit" class="btn-submit">Log in</button>
+        </form>
         <div class="divider"><span>or</span></div>
         <div class="auth-footer">
-          <p>Don't have an account? <a href="signup.html">Create one free</a></p>
-          <a href="../community/feed.html" class="guest-link">
-            <i class="ri-compass-3-line"></i> Browse as guest
-          </a>
+          <p>Don't have an account? <a href="signup.html">Sign up free</a></p>
+          <a href="../community/feed.html" class="guest-link"><i class="ri-compass-3-line"></i> Continue as guest</a>
         </div>
       </div>
     </div>
   </div>
-
-  <script>
-    function togglePw() { const i = document.getElementById('password'); i.type = i.type === 'password' ? 'text' : 'password'; }
-  </script>
+  <script src="../js/env.js"></script>
   <script type="module">
-  import { logIn, getUserProfile, redirectAfterLogin, redirectIfLoggedIn } from '../js/auth.js';
+    import { logIn, getUserProfile, redirectAfterLogin, redirectIfLoggedIn } from '../js/auth.js';
 
-  redirectIfLoggedIn();
+    // Redirect away if already logged in
+    redirectIfLoggedIn();
 
-  const form      = document.getElementById('loginForm');
-  const errorEl   = document.getElementById('errorMsg');
-  const errorTx   = document.getElementById('errorText');
-  const submitBtn = document.getElementById('submitBtn');
+    const form    = document.getElementById('loginForm');
+    const errorEl = document.getElementById('errorMsg');
+    const errorTx = document.getElementById('errorText');
+    const submitBtn = form.querySelector('button[type="submit"]');
 
-  form.addEventListener('submit', async (e) => {
-    e.preventDefault();
-    errorEl.style.display = 'none';
-    submitBtn.textContent  = 'Logging in…';
-    submitBtn.disabled     = true;
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-    try {
-      const user    = await logIn(
-        document.getElementById('email').value.trim(),
-        document.getElementById('password').value
-      );
-      const profile = await getUserProfile(user.uid);
-      redirectAfterLogin(profile.role);
-    } catch (err) {
-      errorEl.style.display = 'flex';
-      errorTx.textContent   = 'Invalid email or password. Please try again.';
-      submitBtn.textContent  = 'Log in';
-      submitBtn.disabled     = false;
-    }
-  });
-</script>
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      errorEl.style.display = 'none';
+
+      const email    = document.getElementById('email').value.trim();
+      const password = document.getElementById('password').value;
+
+      // Client-side validation
+      if (!emailRegex.test(email)) {
+        errorEl.style.display = 'flex';
+        errorTx.textContent   = 'Please enter a valid email address.';
+        return;
+      }
+      if (!password) {
+        errorEl.style.display = 'flex';
+        errorTx.textContent   = 'Please enter your password.';
+        return;
+      }
+
+      submitBtn.textContent  = 'Logging in…';
+      submitBtn.disabled     = true;
+
+      try {
+        const user    = await logIn(email, password);
+        const profile = await getUserProfile(user.uid);
+        redirectAfterLogin(profile.role);
+      } catch (err) {
+        errorEl.style.display = 'flex';
+        errorTx.textContent   = 'Invalid email or password. Please try again.';
+        submitBtn.textContent  = 'Log in';
+        submitBtn.disabled     = false;
+      }
+    });
+  </script>
 </body>
-
 </html>

--- a/auth/signup.html
+++ b/auth/signup.html
@@ -1,269 +1,190 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ShareCare — Sign Up</title>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/remixicon/4.6.0/remixicon.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="../assets/styles.css">
+  <link rel="stylesheet" href="../assets/style.css">
   <style>
-    body {
-      display: flex;
-      flex-direction: column;
-      min-height: 100vh;
-    }
-
-    .auth-page {
-      flex: 1;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: 40px 24px;
-    }
-
-    .auth-card {
-      background: var(--card);
-      border-radius: var(--r-xl);
-      padding: 48px 44px;
-      width: 100%;
-      max-width: 520px;
-      border: 1px solid var(--border-light);
-      box-shadow: var(--shadow-md);
-    }
-
-    .auth-header {
-      text-align: center;
-      margin-bottom: 28px;
-    }
-
-    .auth-header h2 {
-      margin-bottom: 6px;
-      color: var(--text);
-    }
-
-    .auth-header p {
-      font-size: 0.88rem;
-    }
-
-    .form-row {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: 14px;
-    }
-
-    .role-options {
-      display: flex;
-      gap: 10px;
-      margin-top: 8px;
-    }
-
-    .role-opt {
-      flex: 1;
-      padding: 12px 8px;
-      border: 1.5px solid var(--border);
-      border-radius: var(--r);
-      text-align: center;
-      cursor: pointer;
-      font-size: 0.84rem;
-      font-weight: 500;
-      color: var(--text-muted);
-      transition: all 0.2s;
-    }
-
-    .role-opt:hover {
-      border-color: var(--primary);
-      color: var(--primary);
-    }
-
-    .role-opt.selected {
-      border-color: var(--primary);
-      background: var(--primary-light);
-      color: var(--primary-dark);
-    }
-
-    .role-opt i {
-      display: block;
-      font-size: 1.4rem;
-      margin-bottom: 5px;
-    }
-
-    .btn-submit {
-      width: 100%;
-      padding: 13px;
-      background: var(--primary);
-      color: white;
-      border: none;
-      border-radius: var(--r);
-      font-family: 'DM Sans', sans-serif;
-      font-size: 0.95rem;
-      font-weight: 600;
-      cursor: pointer;
-      margin-top: 4px;
-      transition: all 0.2s;
-      box-shadow: 0 4px 14px rgba(92, 141, 122, 0.3);
-    }
-
-    .btn-submit:hover {
-      background: var(--primary-dark);
-      transform: translateY(-1px);
-    }
-
-    .terms {
-      font-size: 0.76rem;
-      color: var(--text-muted);
-      text-align: center;
-      margin-top: 12px;
-      line-height: 1.5;
-    }
-
-    .terms a {
-      color: var(--primary);
-      text-decoration: none;
-    }
-
-    .auth-footer {
-      text-align: center;
-      margin-top: 18px;
-      font-size: 0.85rem;
-      color: var(--text-muted);
-    }
-
-    .auth-footer a {
-      color: var(--primary);
-      font-weight: 600;
-      text-decoration: none;
-    }
+    body{display:flex;min-height:100vh;flex-direction:column;}
+    .auth-wrap{flex:1;display:flex;}
+    .auth-left{width:38%;background:linear-gradient(160deg,var(--primary-dark) 0%,var(--primary) 100%);padding:52px 48px;display:flex;flex-direction:column;justify-content:space-between;position:relative;overflow:hidden;}
+    .auth-left::before{content:'';position:absolute;width:400px;height:400px;border-radius:50%;background:rgba(255,255,255,0.05);bottom:-100px;right:-100px;}
+    .auth-left-logo{display:flex;align-items:center;gap:10px;font-family:'DM Serif Display',serif;font-size:22px;color:white;text-decoration:none;}
+    .auth-left-logo i{color:rgba(255,255,255,0.7);}
+    .auth-left-content h2{font-size:34px;color:white;margin-bottom:14px;}
+    .auth-left-content p{font-size:15px;color:rgba(255,255,255,0.75);line-height:1.7;max-width:280px;}
+    .auth-quote{background:rgba(255,255,255,0.1);border-radius:var(--radius-lg);padding:20px 22px;position:relative;z-index:1;}
+    .auth-quote p{font-size:14px;color:rgba(255,255,255,0.9);font-style:italic;line-height:1.65;margin-bottom:8px;}
+    .auth-quote span{font-size:12px;color:rgba(255,255,255,0.6);}
+    .auth-right{flex:1;display:flex;align-items:center;justify-content:center;padding:40px;background:var(--bg);overflow-y:auto;}
+    .auth-card{background:var(--card);border-radius:var(--radius-xl);padding:44px 40px;width:100%;max-width:460px;border:1px solid var(--border-light);box-shadow:var(--shadow-md);}
+    .auth-card h1{font-size:26px;margin-bottom:6px;}
+    .auth-card>p{font-size:14px;color:var(--text-muted);margin-bottom:28px;}
+    .form-row{display:grid;grid-template-columns:1fr 1fr;gap:14px;}
+    .role-grid{display:grid;grid-template-columns:1fr 1fr 1fr;gap:10px;}
+    .role-opt{border:1.5px solid var(--border);border-radius:var(--radius-md);padding:14px 8px;text-align:center;cursor:pointer;transition:all 0.2s;}
+    .role-opt:hover{border-color:var(--primary);}
+    .role-opt.selected{border-color:var(--primary);background:var(--primary-light);}
+    .role-opt i{font-size:22px;color:var(--text-muted);display:block;margin-bottom:6px;transition:color 0.2s;}
+    .role-opt.selected i{color:var(--primary);}
+    .role-opt span{font-size:13px;font-weight:600;color:var(--text-muted);transition:color 0.2s;}
+    .role-opt.selected span{color:var(--primary-dark);}
+    .toggle-pw{position:absolute;right:14px;top:50%;transform:translateY(-50%);color:var(--text-light);font-size:17px;cursor:pointer;background:none;border:none;}
+    .btn-submit{width:100%;padding:14px;background:var(--primary);color:white;border:none;border-radius:var(--radius-md);font-family:'DM Sans',sans-serif;font-size:15px;font-weight:600;cursor:pointer;margin-top:8px;transition:all 0.2s;box-shadow:0 4px 14px rgba(78,140,117,0.28);}
+    .btn-submit:hover{background:var(--primary-dark);transform:translateY(-1px);}
+    .terms{font-size:12px;color:var(--text-muted);text-align:center;margin-top:12px;line-height:1.55;}
+    .terms a{color:var(--primary);text-decoration:none;}
+    .auth-footer{text-align:center;margin-top:18px;}
+    .auth-footer a{color:var(--primary);font-weight:600;text-decoration:none;font-size:14px;}
+    .error-msg{background:#FEF2F2;border:1px solid #FECACA;border-radius:var(--radius-sm);padding:10px 14px;font-size:13px;color:#991B1B;margin-bottom:16px;display:none;align-items:center;gap:8px;}
   </style>
-  <script src="../js/env.js"></script>
 </head>
-
 <body>
-  <nav class="nav">
-    <a href="../index.html" class="nav-logo"><i class="ri-heart-pulse-fill"></i> ShareCare</a>
-  </nav>
-  <div class="auth-page">
-    <div class="auth-card fade-up">
-      <div class="auth-header">
-        <h2>Join ShareCare</h2>
-        <p>Connect with a community that understands</p>
+  <div class="auth-wrap">
+    <div class="auth-left">
+      <a href="../index.html" class="auth-left-logo"><i class="ri-heart-pulse-fill"></i> ShareCare</a>
+      <div class="auth-left-content">
+        <h2>Join a community<br>that gets it.</h2>
+        <p>Thousands of people managing diabetes sharing what actually works in real life.</p>
       </div>
-      <div class="error-msg" id="errorMsg" style="display:none;">
-  <i class="ri-error-warning-line"></i><span id="errorText"></span>
-</div>
+      <div class="auth-quote">
+        <p>"Finding this community changed how I think about managing my condition — less clinical, more human."</p>
+        <span>— ShareCare member, Type 2</span>
+      </div>
+    </div>
+    <div class="auth-right">
+      <div class="auth-card">
+        <h1>Create your account</h1>
+        <p>Join ShareCare — it only takes a minute</p>
+        <div class="error-msg" id="errorMsg"><i class="ri-error-warning-line"></i><span id="errorText"></span></div>
+        <form id="signupForm">
+          <div class="form-row">
+            <div class="form-group">
+              <label class="form-label">First name</label>
+              <input type="text" class="form-input" id="firstName" placeholder="Ravi" required>
+            </div>
+            <div class="form-group">
+              <label class="form-label">Last name</label>
+              <input type="text" class="form-input" id="lastName" placeholder="Kumar" required>
+            </div>
+          </div>
+          <div class="form-group">
+            <label class="form-label">Email address</label>
+            <div class="input-wrap"><i class="ri-mail-line input-icon"></i>
+              <input type="email" class="form-input has-icon" id="email" placeholder="name@example.com" required>
+            </div>
+          </div>
+          <div class="form-group">
+            <label class="form-label">Password</label>
+            <div class="input-wrap"><i class="ri-lock-2-line input-icon"></i>
+              <input type="password" class="form-input has-icon" id="password" placeholder="Min. 8 characters" required>
+              <button type="button" class="toggle-pw" onclick="togglePw()"><i class="ri-eye-off-line" id="pwIcon"></i></button>
+            </div>
+            <div class="form-hint">At least 8 characters</div>
+          </div>
+          <div class="form-group">
+            <label class="form-label">I am a</label>
+            <div class="role-grid">
+              <div class="role-opt selected" onclick="selectRole(this,'patient')">
+                <i class="ri-user-heart-line"></i><span>Patient</span>
+              </div>
+              <div class="role-opt" onclick="selectRole(this,'caregiver')">
+                <i class="ri-parent-line"></i><span>Caregiver</span>
+              </div>
+              <div class="role-opt" onclick="selectRole(this,'pharmacy')">
+                <i class="ri-store-2-line"></i><span>Pharmacy</span>
+              </div>
+            </div>
+            <input type="hidden" id="role" value="patient">
+          </div>
 
-  <form id="signupForm">
-    <div class="form-row">
-      <div class="form-group">
-        <label class="label">First name</label>
-        <div class="input-wrap">
-          <i class="ri-user-line i-left"></i>
-          <input type="text" class="input" id="firstName" placeholder="Ravi" required>
+          <button type="submit" class="btn-submit" id="submitBtn">Create account</button>
+          <p class="terms">By signing up you agree to our <a href="#">Terms</a> and <a href="#">Privacy Policy</a>.</p>
+        </form>
+        <div class="auth-footer">
+          <p style="font-size:14px;color:var(--text-muted);">Already have an account? <a href="login.html">Log in</a></p>
         </div>
       </div>
-      <div class="form-group">
-        <label class="label">Last name</label>
-        <div class="input-wrap">
-          <i class="ri-user-line i-left"></i>
-          <input type="text" class="input" id="lastName" placeholder="Kumar" required>
-        </div>
-      </div>
-    </div>
-    <div class="form-group">
-      <label class="label">Email address</label>
-      <div class="input-wrap">
-        <i class="ri-mail-line i-left"></i>
-        <input type="email" class="input" id="email" placeholder="name@example.com" required>
-      </div>
-    </div>
-    <div class="form-group">
-      <label class="label">Password</label>
-      <div class="input-wrap">
-        <i class="ri-lock-2-line i-left"></i>
-        <input type="password" class="input" id="password" placeholder="••••••••">
-        <i class="ri-eye-off-line i-right" onclick="togglePw()"></i>
-      </div>
-      <div class="hint">At least 8 characters</div>
-    </div>
-    <div class="form-group">
-      <label class="label">I am a</label>
-      <div class="role-options">
-        <div class="role-opt selected" onclick="selectRole(this, 'patient')">
-          <i class="ri-user-heart-line"></i>Patient
-        </div>
-        <div class="role-opt" onclick="selectRole(this, 'caregiver')">
-          <i class="ri-parent-line"></i>Caregiver
-        </div>
-        <div class="role-opt" onclick="selectRole(this, 'pharmacy')">
-          <i class="ri-store-2-line"></i>Pharmacy
-        </div>
-      </div>
-      <input type="hidden" id="role" value="patient">
-    </div>
-    <div class="form-group" id="pharmacyNameGroup" style="display:none;">
-      <label class="label">Pharmacy name</label>
-      <div class="input-wrap">
-        <i class="ri-store-2-line i-left"></i>
-        <input type="text" class="input" id="pharmacyName" placeholder="e.g. Apollo Pharmacy, Koramangala">
-      </div>
-    </div>
-    <button type="submit" class="btn-submit" id="submitBtn">Create account</button>
-    <p class="terms">By signing up you agree to our <a href="#">Terms</a> and <a href="#">Privacy Policy</a>.</p>
-  </form>
-      <div class="divider"><span>or</span></div>
-      <div class="auth-footer">Already have an account? <a href="login.html">Log in</a></div>
     </div>
   </div>
   <script>
-  function selectRole(el, role) {
-    document.querySelectorAll('.role-opt').forEach(o => o.classList.remove('selected'));
-    el.classList.add('selected');
-    document.getElementById('role').value = role;
-    document.getElementById('pharmacyNameGroup').style.display = role === 'pharmacy' ? 'block' : 'none';
-  }
-  function togglePw() { const i = document.getElementById('password'); i.type = i.type === 'password' ? 'text' : 'password'; }
+    function selectRole(el, role) {
+      document.querySelectorAll('.role-opt').forEach(o => o.classList.remove('selected'));
+      el.classList.add('selected');
+      document.getElementById('role').value = role;
+    }
+    function togglePw(){const pw=document.getElementById('password');const icon=document.getElementById('pwIcon');if(pw.type==='password'){pw.type='text';icon.className='ri-eye-line';}else{pw.type='password';icon.className='ri-eye-off-line';}}
   </script>
+  <script src="../js/env.js"></script>
   <script type="module">
-  import { signUp, redirectAfterLogin, redirectIfLoggedIn } from '../js/auth.js';
+    import { signUp, redirectAfterLogin, redirectIfLoggedIn } from '../js/auth.js';
 
-  redirectIfLoggedIn();
+    redirectIfLoggedIn();
 
-  const form      = document.getElementById('signupForm');
-  const errorEl   = document.getElementById('errorMsg');
-  const errorTx   = document.getElementById('errorText');
-  const submitBtn = document.getElementById('submitBtn');
+    const form      = document.getElementById('signupForm');
+    const errorEl   = document.getElementById('errorMsg');
+    const errorTx   = document.getElementById('errorText');
+    const submitBtn = document.getElementById('submitBtn');
 
-  form.addEventListener('submit', async (e) => {
-    e.preventDefault();
-    errorEl.style.display = 'none';
+    const emailRegex    = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    const nameRegex     = /^[a-zA-Z\s'-]{2,50}$/;
+    const phoneRegex    = /^[0-9\s\-\+\(\)]{7,15}$/;
+    const passwordRegex = /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,}$/;
 
-    const role     = document.getElementById('role').value;
-    const name     = `${document.getElementById('firstName').value.trim()} ${document.getElementById('lastName').value.trim()}`;
-    const email    = document.getElementById('email').value.trim();
-    const password = document.getElementById('password').value;
-
-    if (password.length < 8) {
+    function showErr(msg) {
       errorEl.style.display = 'flex';
-      errorTx.textContent   = 'Password must be at least 8 characters.';
-      return;
+      errorTx.textContent   = msg;
     }
 
-    submitBtn.textContent = 'Creating account…';
-    submitBtn.disabled    = true;
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      errorEl.style.display = 'none';
 
-    try {
-      await signUp(name, email, password, role);
-      redirectAfterLogin(role);
-    } catch (err) {
-      errorEl.style.display = 'flex';
-      errorTx.textContent   = err.code === 'auth/email-already-in-use'
-        ? 'An account with this email already exists.'
-        : err.message;
-      submitBtn.textContent = 'Create account';
-      submitBtn.disabled    = false;
-    }
-  });
-</script>
+      const role      = document.getElementById('role').value;
+      const firstName = document.getElementById('firstName').value.trim();
+      const lastName  = document.getElementById('lastName').value.trim();
+      const name      = `${firstName} ${lastName}`;
+      const email     = document.getElementById('email').value.trim();
+      const password  = document.getElementById('password').value;
+
+      // Name validation
+      if (!nameRegex.test(firstName)) { showErr('First name should only contain letters (2–50 characters).'); return; }
+      if (!nameRegex.test(lastName))  { showErr('Last name should only contain letters (2–50 characters).'); return; }
+
+      // Email validation
+      if (!emailRegex.test(email)) { showErr('Please enter a valid email address.'); return; }
+
+      // Password validation
+      if (password.length < 8) { showErr('Password must be at least 8 characters.'); return; }
+      if (!passwordRegex.test(password)) { showErr('Password must contain at least one letter and one number.'); return; }
+
+      // Pharmacy field validation
+      if (role === 'pharmacy') {
+        const pName  = document.getElementById('pharmacyName')?.value.trim();
+        const pArea  = document.getElementById('pharmacyArea')?.value.trim();
+        const pAddr  = document.getElementById('pharmacyAddress')?.value.trim();
+        const pPhone = document.getElementById('pharmacyPhone')?.value.trim();
+        if (pName && pName.length < 2)         { showErr('Pharmacy name must be at least 2 characters.'); return; }
+        if (pPhone && !phoneRegex.test(pPhone)) { showErr('Please enter a valid phone number.'); return; }
+      }
+
+      submitBtn.textContent = 'Creating account…';
+      submitBtn.disabled    = true;
+
+      try {
+        await signUp(name, email, password, role);
+        redirectAfterLogin(role);
+      } catch (err) {
+        console.error('Signup error:', err);
+        errorEl.style.display = 'flex';
+        errorTx.textContent   = err.code === 'auth/email-already-in-use'
+          ? 'An account with this email already exists.'
+          : err.message;
+        submitBtn.textContent = 'Create account';
+        submitBtn.disabled    = false;
+      }
+    });
+  </script>
 </body>
-
 </html>

--- a/firestore.rules
+++ b/firestore.rules
@@ -37,7 +37,7 @@ service cloud.firestore {
     // Only the pharmacy owner can update their own record
     match /pharmacies/{pharmacyId} {
       allow read:   if isSignedIn();
-      allow create: if isPharmacy();
+      allow create: if isSignedIn();
       allow update: if isSignedIn() && isOwner(resource.data.ownerId);
       allow delete: if false;
     }
@@ -54,6 +54,8 @@ service cloud.firestore {
       allow update: if isSignedIn() && (
                       // Patient can cancel (status: pending → cancelled)
                       (isOwner(resource.data.patientId) && request.resource.data.status == 'cancelled') ||
+                      // Patient can set delivery preference (only when status is ready)
+                      (isOwner(resource.data.patientId) && resource.data.status == 'ready' && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['deliveryPreference', 'updatedAt'])) ||
                       // Pharmacy can update status
                       resource.data.pharmacyId == get(/databases/$(database)/documents/users/$(request.auth.uid)).data.pharmacyId
                     );

--- a/js/patient.js
+++ b/js/patient.js
@@ -34,10 +34,12 @@ export async function getPharmacies() {
 
 
 // ── Submit a new medicine request ─────────────────────────────────────────────
-export async function submitRequest(patientId, pharmacyId, medicines, notes, preferredPickupTime) {
+export async function submitRequest(patientId, patientName, pharmacyId, pharmacyName, medicines, notes, preferredPickupTime) {
   const ref = await addDoc(collection(db, "requests"), {
     patientId,
+    patientName,
     pharmacyId,
+    pharmacyName,
     medicines,         // array of { name, quantity }
     notes,
     preferredPickupTime,
@@ -85,6 +87,15 @@ export async function cancelRequest(requestId) {
   }
   await updateDoc(doc(db, "requests", requestId), {
     status:    "cancelled",
+    updatedAt: serverTimestamp()
+  });
+}
+
+
+// ── Set delivery preference (called when status is ready) ────────────────────
+export async function setDeliveryPreference(requestId, preference) {
+  await updateDoc(doc(db, "requests", requestId), {
+    deliveryPreference: preference,
     updatedAt: serverTimestamp()
   });
 }

--- a/js/pharmacy.js
+++ b/js/pharmacy.js
@@ -1,0 +1,174 @@
+import { db } from "./firebase-config.js";
+import {
+  collection,
+  addDoc,
+  getDocs,
+  getDoc,
+  doc,
+  query,
+  where,
+  orderBy,
+  updateDoc,
+  setDoc,
+  serverTimestamp,
+  onSnapshot
+} from "https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js";
+
+
+// ── Get pharmacy profile for a given user ─────────────────────────────────────
+export async function getPharmacyProfile(userId) {
+  const userSnap = await getDoc(doc(db, "users", userId));
+  if (!userSnap.exists()) throw new Error("User not found");
+  const userData = userSnap.data();
+  if (!userData.pharmacyId) throw new Error("No pharmacy linked to this account");
+  const pharmSnap = await getDoc(doc(db, "pharmacies", userData.pharmacyId));
+  if (!pharmSnap.exists()) throw new Error("Pharmacy profile not found");
+  return { id: pharmSnap.id, ...pharmSnap.data() };
+}
+
+
+// ── Register a new pharmacy (called on first pharmacy signup) ─────────────────
+export async function registerPharmacy(userId, name, address, area, phone) {
+  console.log('A. registerPharmacy called with uid:', userId);
+  const pharmRef = doc(collection(db, "pharmacies"));
+  console.log('B. pharmRef created:', pharmRef.id);
+  await setDoc(pharmRef, {
+    name,
+    address,
+    area,
+    phone,
+    ownerId:   userId,
+    createdAt: serverTimestamp()
+  });
+  console.log('C. setDoc done');
+  await updateDoc(doc(db, "users", userId), {
+    pharmacyId: pharmRef.id
+  });
+  console.log('D. updateDoc done');
+  return pharmRef.id;
+}
+
+
+// ── Live listener for all orders for a pharmacy ───────────────────────────────
+export function listenToPharmacyOrders(pharmacyId, callback) {
+  const q = query(
+    collection(db, "requests"),
+    where("pharmacyId", "==", pharmacyId),
+    orderBy("createdAt", "desc")
+  );
+  return onSnapshot(q, (snapshot) => {
+    const orders = snapshot.docs.map(d => ({ id: d.id, ...d.data() }));
+    callback(orders);
+  });
+}
+
+
+// ── Fetch orders filtered by status ──────────────────────────────────────────
+export function listenToPharmacyOrdersByStatus(pharmacyId, status, callback) {
+  const q = query(
+    collection(db, "requests"),
+    where("pharmacyId", "==", pharmacyId),
+    where("status", "==", status),
+    orderBy("createdAt", "desc")
+  );
+  return onSnapshot(q, (snapshot) => {
+    const orders = snapshot.docs.map(d => ({ id: d.id, ...d.data() }));
+    callback(orders);
+  });
+}
+
+
+// ── Get a single order ────────────────────────────────────────────────────────
+export async function getOrder(orderId) {
+  const snap = await getDoc(doc(db, "requests", orderId));
+  if (!snap.exists()) throw new Error("Order not found");
+  return { id: snap.id, ...snap.data() };
+}
+
+
+// ── Live listener for a single order ─────────────────────────────────────────
+export function listenToOrder(orderId, callback) {
+  return onSnapshot(doc(db, "requests", orderId), (snap) => {
+    if (snap.exists()) callback({ id: snap.id, ...snap.data() });
+  });
+}
+
+
+// ── Update order status ───────────────────────────────────────────────────────
+export async function updateOrderStatus(orderId, newStatus, pharmacyNotes = "") {
+  const validTransitions = {
+    pending:   ["confirmed", "cancelled"],
+    confirmed: ["ready",     "cancelled"],
+    ready:     ["collected"],
+    collected: [],
+    cancelled: []
+  };
+
+  const order = await getOrder(orderId);
+  const allowed = validTransitions[order.status] || [];
+
+  if (!allowed.includes(newStatus)) {
+    throw new Error(`Cannot move from "${order.status}" to "${newStatus}".`);
+  }
+
+  const update = {
+    status:    newStatus,
+    updatedAt: serverTimestamp()
+  };
+  if (pharmacyNotes) update.pharmacyNotes = pharmacyNotes;
+
+  await updateDoc(doc(db, "requests", orderId), update);
+}
+
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+export function getStatusLabel(status) {
+  const labels = {
+    pending:   "Pending",
+    confirmed: "Confirmed",
+    ready:     "Ready for Pickup",
+    collected: "Collected",
+    cancelled: "Cancelled"
+  };
+  return labels[status] || "Unknown";
+}
+
+export function getStatusClass(status) {
+  const classes = {
+    pending:   "status-pending",
+    confirmed: "status-confirmed",
+    ready:     "status-ready",
+    collected: "status-collected",
+    cancelled: "badge-danger"
+  };
+  return classes[status] || "badge-gray";
+}
+
+export function getNextStatus(currentStatus) {
+  const next = {
+    pending:   "confirmed",
+    confirmed: "ready",
+    ready:     "collected"
+  };
+  return next[currentStatus] || null;
+}
+
+export function getNextStatusLabel(currentStatus) {
+  const labels = {
+    pending:   "Confirm Order",
+    confirmed: "Mark as Ready",
+    ready:     "Mark as Collected"
+  };
+  return labels[currentStatus] || null;
+}
+
+export function getOrderCounts(orders) {
+  return {
+    total:     orders.length,
+    pending:   orders.filter(o => o.status === "pending").length,
+    confirmed: orders.filter(o => o.status === "confirmed").length,
+    ready:     orders.filter(o => o.status === "ready").length,
+    collected: orders.filter(o => o.status === "collected").length,
+    cancelled: orders.filter(o => o.status === "cancelled").length
+  };
+}

--- a/patient/dashboard.html
+++ b/patient/dashboard.html
@@ -115,7 +115,8 @@
       document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
       el.classList.add('active');
       document.querySelectorAll('.request-card').forEach(c => {
-        c.style.display = (status === 'all' || c.dataset.status === status) ? 'flex' : 'none';
+        const hiddenInAll = status === 'all' && (c.dataset.status === 'collected' || c.dataset.status === 'cancelled');
+        c.style.display = (!hiddenInAll && (status === 'all' || c.dataset.status === status)) ? 'flex' : 'none';
       });
     }
   </script>

--- a/patient/new-request.html
+++ b/patient/new-request.html
@@ -164,7 +164,8 @@
 
     requireAuth(async (profile) => {
       document.getElementById('userName').textContent = profile.name || 'User';
-      window.__currentUserId = profile.uid;
+      window.__currentUserId  = profile.uid;
+      window.__currentUserName = profile.name || 'Patient';
       loadPharmacies();
     });
 
@@ -210,7 +211,9 @@
       try {
         await submitRequest(
           window.__currentUserId,
+          window.__currentUserName,
           pharmacyId,
+          pharmacyName,
           medicines,
           document.getElementById('notes').value,
           document.getElementById('pickupTime').value

--- a/patient/request-detail.html
+++ b/patient/request-detail.html
@@ -38,6 +38,19 @@
     .pharmacy-info-row{display:flex;align-items:center;gap:10px;margin-bottom:10px;}
     .pharmacy-info-row i{color:var(--primary);font-size:17px;}
     .pharmacy-info-row span{font-size:14px;}
+    .delivery-card{background:linear-gradient(135deg,var(--primary-light),var(--accent-light));border:1px solid var(--primary-mid);border-radius:var(--radius-lg);padding:20px 24px;margin-top:20px;}
+    .delivery-card h4{font-family:'DM Serif Display',serif;font-size:17px;margin-bottom:6px;}
+    .delivery-card p{font-size:13px;color:var(--text-muted);margin-bottom:16px;}
+    .delivery-opts{display:grid;grid-template-columns:1fr 1fr;gap:10px;}
+    .delivery-opt{border:2px solid var(--border);border-radius:var(--radius-md);padding:14px;text-align:center;cursor:pointer;background:var(--card);transition:all 0.2s;}
+    .delivery-opt:hover{border-color:var(--primary);}
+    .delivery-opt i{font-size:24px;display:block;margin-bottom:6px;color:var(--text-muted);}
+    .delivery-opt span{font-size:13px;font-weight:600;color:var(--text-muted);}
+    .delivery-opt.selected{border-color:var(--primary);background:var(--primary-light);}
+    .delivery-opt.selected i,.delivery-opt.selected span{color:var(--primary-dark);}
+    .delivery-confirmed{display:flex;align-items:center;gap:10px;padding:14px 16px;background:var(--card);border-radius:var(--radius-md);border:1px solid var(--border-light);}
+    .delivery-confirmed i{font-size:20px;color:var(--primary);}
+    .delivery-confirmed span{font-size:14px;font-weight:500;}
   </style>
 </head>
 <body>
@@ -99,6 +112,34 @@
                 <div class="info-icon" style="background:var(--accent-light);color:var(--accent-dark);"><i class="ri-store-2-line"></i></div>
                 <div><div class="info-label">Pharmacy Notes</div><div class="info-val" id="rPharmacyNotes">—</div></div>
               </div>
+
+              <!-- Delivery preference — shown only when status is ready -->
+              <div id="deliverySection" style="display:none;">
+                <div class="delivery-card">
+                  <h4>Your order is ready!</h4>
+                  <p>How would you like to receive your medicines?</p>
+                  <div id="deliveryTimeWarning" style="display:none;background:#FFFBEB;border:1px solid #FDE68A;border-radius:var(--radius-md);padding:10px 14px;font-size:13px;color:#78500A;margin-bottom:12px;">
+                    <i class="ri-time-line" style="margin-right:6px;"></i>
+                    Delivery is only available between <strong>9 AM – 9 PM</strong>. Please come back during delivery hours or choose pickup.
+                  </div>
+                  <div class="delivery-opts" id="deliveryOpts">
+                    <div class="delivery-opt" id="optPickup" onclick="chooseDelivery('pickup')">
+                      <i class="ri-walk-line"></i>
+                      <span>Pick up in person</span>
+                    </div>
+                    <div class="delivery-opt" id="optDelivery" onclick="chooseDelivery('delivery')">
+                      <i class="ri-e-bike-line"></i>
+                      <span>Request delivery</span>
+                    </div>
+                  </div>
+                  <div id="deliveryConfirmed" style="display:none;margin-top:12px;">
+                    <div class="delivery-confirmed">
+                      <i class="ri-checkbox-circle-fill"></i>
+                      <span id="deliveryConfirmedText">Preference saved.</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
           <div>
@@ -124,7 +165,7 @@
   <script src="../js/env.js"></script>
   <script type="module">
     import { requireAuth, logOut }                         from '../js/auth.js';
-    import { listenToRequest, cancelRequest, getStatusLabel, getStatusClass } from '../js/patient.js';
+    import { listenToRequest, cancelRequest, getStatusLabel, getStatusClass, setDeliveryPreference } from '../js/patient.js';
     import { db }                                          from '../js/firebase-config.js';
     import { doc, getDoc }                                 from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js';
 
@@ -203,6 +244,28 @@
           };
         }
 
+        // Delivery section — show when status is ready
+        const deliverySection = document.getElementById('deliverySection');
+        if (deliverySection) {
+          if (r.status === 'ready') {
+            deliverySection.style.display = 'block';
+            // If preference already set, show confirmed state
+            if (r.deliveryPreference) {
+              document.getElementById('deliveryOpts').style.display = 'none';
+              document.getElementById('deliveryConfirmed').style.display = 'block';
+              const label = r.deliveryPreference === 'delivery'
+                ? 'Delivery requested — pharmacy will dispatch your order.'
+                : 'You will pick up in person. Visit the pharmacy when ready.';
+              document.getElementById('deliveryConfirmedText').textContent = label;
+            } else {
+              document.getElementById('deliveryOpts').style.display = 'grid';
+              document.getElementById('deliveryConfirmed').style.display = 'none';
+            }
+          } else {
+            deliverySection.style.display = 'none';
+          }
+        }
+
         // Pharmacy contact details
         try {
           const ps = await getDoc(doc(db, 'pharmacies', r.pharmacyId));
@@ -214,6 +277,45 @@
         } catch (_) {}
       });
     });
+
+    window.chooseDelivery = async (preference) => {
+      if (!id) return;
+
+      // Enforce delivery time window: 9 AM – 9 PM
+      if (preference === 'delivery') {
+        const hour = new Date().getHours();
+        const warning = document.getElementById('deliveryTimeWarning');
+        if (hour < 9 || hour >= 21) {
+          warning.style.display = 'block';
+          document.getElementById('optDelivery').classList.remove('selected');
+          return;
+        } else {
+          warning.style.display = 'none';
+        }
+      }
+
+      // Highlight selected option
+      document.getElementById('optPickup').classList.toggle('selected', preference === 'pickup');
+      document.getElementById('optDelivery').classList.toggle('selected', preference === 'delivery');
+
+      try {
+        await setDeliveryPreference(id, preference);
+        // Only show confirmed state after successful save
+        document.getElementById('deliveryOpts').style.display = 'none';
+        document.getElementById('deliveryConfirmed').style.display = 'block';
+        const label = preference === 'delivery'
+          ? 'Delivery requested — the pharmacy will dispatch your order.'
+          : 'You will pick up in person. Visit the pharmacy when your order is ready.';
+        document.getElementById('deliveryConfirmedText').textContent = label;
+      } catch (err) {
+        // Reset selection on failure
+        document.getElementById('optPickup').classList.remove('selected');
+        document.getElementById('optDelivery').classList.remove('selected');
+        document.getElementById('deliveryOpts').style.display = 'grid';
+        document.getElementById('deliveryConfirmed').style.display = 'none';
+        alert('Failed to save preference. Please try again.');
+      }
+    };
   </script>
 </body>
 </html>

--- a/pharmacy/dashboard.html
+++ b/pharmacy/dashboard.html
@@ -1,119 +1,269 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ShareCare — Pharmacy Dashboard</title>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/remixicon/4.6.0/remixicon.min.css" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400&family=DM+Serif+Display:ital@0;1&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="../assets/style.css">
-    <style>
-        body{display:flex;}
-        .stats-row{display:grid;grid-template-columns:repeat(4,1fr);gap:16px;margin-bottom:28px;}
-        .stat-card{background:var(--card);border-radius:16px;padding:20px;border:1px solid var(--border);}
-        .stat-label{font-size:0.78rem;color:var(--text-muted);margin-bottom:8px;font-weight:500;}
-        .stat-val{font-family:var(--font-display);font-size:1.8rem;color:var(--text);}
-        .stat-sub{font-size:0.75rem;color:var(--text-muted);margin-top:4px;}
-        .stat-icon{float:right;width:36px;height:36px;border-radius:10px;display:flex;align-items:center;justify-content:center;font-size:1.1rem;}
-        .si-amber{background:#FEF9C3;color:#CA8A04;}
-        .si-blue{background:#EFF6FF;color:#3B82F6;}
-        .si-green{background:#F0FDF4;color:#16A34A;}
-        .si-gray{background:var(--bg-alt);color:var(--text-muted);}
-        .tabs{display:flex;gap:4px;background:var(--bg-alt);padding:4px;border-radius:12px;margin-bottom:24px;width:fit-content;}
-        .tab{padding:7px 16px;border-radius:9px;font-size:0.875rem;font-weight:500;cursor:pointer;transition:all 0.2s;color:var(--text-muted);border:none;background:transparent;font-family:var(--font-body);}
-        .tab.active{background:var(--card);color:var(--text);font-weight:600;box-shadow:0 1px 4px rgba(0,0,0,0.06);}
-        .order-card{background:var(--card);border-radius:16px;padding:20px 24px;border:1px solid var(--border);display:grid;grid-template-columns:auto 1fr auto auto;align-items:center;gap:18px;transition:all 0.2s;cursor:pointer;text-decoration:none;color:var(--text);margin-bottom:12px;}
-        .order-card:hover{transform:translateY(-2px);box-shadow:0 6px 20px rgba(44,58,53,0.08);border-color:var(--primary-mid);}
-        .order-card.urgent{border-left:3px solid var(--accent);}
-        .ord-icon{width:44px;height:44px;border-radius:12px;background:var(--primary-light);display:flex;align-items:center;justify-content:center;font-size:1.2rem;color:var(--primary);flex-shrink:0;}
-        .ord-patient{font-size:0.78rem;color:var(--text-muted);margin-bottom:3px;}
-        .ord-meds{font-size:0.9rem;font-weight:600;}
-        .ord-meta{font-size:0.75rem;color:var(--text-muted);margin-top:4px;display:flex;gap:12px;}
-        .ord-time{font-size:0.78rem;color:var(--text-muted);text-align:right;}
-        .search-filter-row{display:flex;align-items:center;gap:12px;margin-bottom:20px;}
-        .sc-search{display:flex;align-items:center;gap:8px;background:var(--card);border:1px solid var(--border);padding:9px 16px;border-radius:999px;flex:1;max-width:320px;}
-        .sc-search input{border:none;outline:none;background:transparent;font-family:var(--font-body);font-size:0.875rem;color:var(--text);width:100%;}
-        .filter-btn{display:flex;align-items:center;gap:6px;padding:9px 16px;border-radius:999px;background:var(--card);border:1px solid var(--border);font-size:0.82rem;font-weight:500;cursor:pointer;color:var(--text-muted);font-family:var(--font-body);transition:all 0.2s;}
-        .filter-btn:hover{border-color:var(--primary);color:var(--primary);}
-    </style>
+  <meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ShareCare — Pharmacy Dashboard</title>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/remixicon/4.6.0/remixicon.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="../assets/style.css">
+  <style>
+    /* === CRITICAL LAYOUT === */
+    html,body{margin:0;padding:0;}
+
+    .stats-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:16px;margin-bottom:28px;}
+    .stat-card{background:var(--card);border-radius:var(--radius-lg);padding:20px 22px;border:1px solid var(--border-light);display:flex;align-items:center;gap:14px;}
+    .stat-icon{width:44px;height:44px;border-radius:var(--radius-md);display:flex;align-items:center;justify-content:center;font-size:20px;flex-shrink:0;}
+    .stat-val{font-family:'DM Serif Display',serif;font-size:24px;}
+    .stat-label{font-size:12px;color:var(--text-muted);margin-top:2px;}
+    .tab-bar{display:flex;gap:4px;background:var(--bg-alt);padding:4px;border-radius:var(--radius-full);margin-bottom:20px;width:fit-content;}
+    .tab{padding:7px 18px;border-radius:var(--radius-full);font-size:13px;font-weight:600;color:var(--text-muted);cursor:pointer;transition:all 0.2s;}
+    .tab.active{background:var(--card);color:var(--text);box-shadow:var(--shadow-sm);}
+    .orders-list{display:flex;flex-direction:column;gap:12px;}
+    .order-card{background:var(--card);border-radius:var(--radius-lg);padding:20px 24px;border:1px solid var(--border-light);display:flex;align-items:center;gap:16px;transition:box-shadow 0.2s,border-color 0.2s;cursor:pointer;text-decoration:none;color:var(--text);}
+    .order-card:hover{box-shadow:var(--shadow-md);border-color:var(--primary-mid);}
+    .order-icon{width:44px;height:44px;border-radius:var(--radius-md);background:var(--accent-light);color:var(--accent-dark);display:flex;align-items:center;justify-content:center;font-size:20px;flex-shrink:0;}
+    .order-main{flex:1;}
+    .order-patient{font-size:14px;font-weight:700;margin-bottom:3px;}
+    .order-meds{font-size:13px;color:var(--text-muted);margin-bottom:3px;}
+    .order-time{font-size:12px;color:var(--text-light);}
+    .order-right{display:flex;flex-direction:column;align-items:flex-end;gap:8px;}
+    .new-badge{background:var(--accent);color:white;font-size:11px;font-weight:700;padding:2px 8px;border-radius:var(--radius-full);}
+    .modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,0.4);z-index:500;display:flex;align-items:center;justify-content:center;}
+    .modal-card{background:var(--card);border-radius:var(--radius-xl);padding:36px 40px;width:100%;max-width:480px;box-shadow:var(--shadow-lg);}
+    .modal-title{font-family:'DM Serif Display',serif;font-size:22px;margin-bottom:6px;}
+    .modal-sub{font-size:14px;color:var(--text-muted);margin-bottom:24px;}
+  </style>
 </head>
 <body>
-<aside class="sc-sidebar">
-    <a href="../index.html" class="sc-logo"><i class="ri-heart-pulse-fill"></i> ShareCare</a>
-    <ul class="sc-sidebar-nav">
-        <li><a href="dashboard.html" class="sc-sidebar-item active"><i class="ri-dashboard-line"></i> Orders</a></li>
-        <li><a href="#" class="sc-sidebar-item"><i class="ri-notification-3-line"></i> Notifications <span class="sc-nav-badge">3</span></a></li>
-        <li><a href="#" class="sc-sidebar-item"><i class="ri-settings-4-line"></i> Settings</a></li>
-    </ul>
-    <div class="sc-sidebar-footer">
+  <div class="sc-app">
+    <aside class="sc-sidebar">
+      <a href="../index.html" class="sc-logo"><i class="ri-heart-pulse-fill"></i> ShareCare</a>
+      <div class="sc-sidebar-section">Pharmacy</div>
+      <ul class="sc-sidebar-menu">
+        <li><a href="dashboard.html" class="sc-sidebar-item active"><i class="ri-dashboard-line"></i> All Orders</a></li>
+      </ul>
+      <div class="sc-sidebar-footer">
         <div class="sc-user-chip">
-            <img src="https://images.unsplash.com/photo-1576091160550-2173dba999ef?w=80&auto=format&fit=crop" alt="Pharmacy">
-            <div><div class="sc-user-chip-name">Apollo Pharmacy</div><div class="sc-user-chip-role">Koramangala</div></div>
-            <i class="ri-logout-box-r-line" onclick="logOut()"></i>
+          <img src="https://images.unsplash.com/photo-1560250097-0b93528c311a?w=80&q=80" alt="Pharmacy">
+          <div><div class="sc-user-name" id="pharmacyName">Loading...</div><div class="sc-user-role">Pharmacy</div></div>
+          <i class="ri-logout-box-r-line sc-logout" onclick="logOut()"></i>
         </div>
+      </div>
+    </aside>
+    <div class="sc-main">
+      <div class="sc-topbar">
+        <div><div class="sc-topbar-title">Order Management</div><div class="sc-topbar-sub">All incoming medicine requests from patients</div></div>
+        <div class="sc-topbar-right">
+          <div class="search-bar"><i class="ri-search-line"></i><input type="text" placeholder="Search patient or medicine..." id="searchInput" oninput="filterSearch(this.value)"></div>
+          <div class="notif-btn"><i class="ri-notification-3-line"></i><div class="notif-dot" id="notifDot" style="display:none;"></div></div>
+        </div>
+      </div>
+      <div class="sc-content">
+        <div class="stats-grid">
+          <div class="stat-card">
+            <div class="stat-icon" style="background:#FFFBEB;color:#92610A;"><i class="ri-time-line"></i></div>
+            <div><div class="stat-val" id="pendingCount">0</div><div class="stat-label">Pending</div></div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-icon" style="background:#EFF6FF;color:#1D4ED8;"><i class="ri-check-double-line"></i></div>
+            <div><div class="stat-val" id="confirmedCount">0</div><div class="stat-label">Confirmed</div></div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-icon" style="background:#ECFDF5;color:#065F46;"><i class="ri-checkbox-circle-line"></i></div>
+            <div><div class="stat-val" id="readyCount">0</div><div class="stat-label">Ready for Pickup</div></div>
+          </div>
+          <div class="stat-card">
+            <div class="stat-icon" style="background:var(--bg-alt);color:var(--text-muted);"><i class="ri-archive-line"></i></div>
+            <div><div class="stat-val" id="collectedCount">0</div><div class="stat-label">Collected Today</div></div>
+          </div>
+        </div>
+
+        <div class="tab-bar">
+          <div class="tab active" onclick="filterTab(this,'all')">All</div>
+          <div class="tab" onclick="filterTab(this,'pending')">Pending</div>
+          <div class="tab" onclick="filterTab(this,'confirmed')">Confirmed</div>
+          <div class="tab" onclick="filterTab(this,'ready')">Ready</div>
+          <div class="tab" onclick="filterTab(this,'collected')">Collected</div>
+        </div>
+
+        <div class="orders-list" id="ordersList">
+          <div class="empty-state" id="emptyState" style="display:none;">
+            <i class="ri-inbox-line"></i>
+            <h3>No orders yet</h3>
+            <p>When patients submit medicine requests to your pharmacy, they'll appear here.</p>
+          </div>
+        </div>
+      </div>
     </div>
-</aside>
-<div class="sc-main">
-    <div class="sc-topbar">
-        <div><div class="sc-topbar-title">Order Management</div><div class="sc-topbar-sub">Apollo Pharmacy, Koramangala · Today</div></div>
-        <div style="display:flex;align-items:center;gap:10px;">
-            <div class="notif-btn"><i class="ri-notification-3-line"></i><div class="notif-dot"></div></div>
-        </div>
+  </div>
+  <!-- Pharmacy Setup Modal -->
+  <div class="modal-overlay" id="setupModal" style="display:none;">
+    <div class="modal-card">
+      <div class="modal-title">Set up your pharmacy</div>
+      <div class="modal-sub">Add your pharmacy details so patients can send you requests.</div>
+      <div id="setupError" class="error-msg" style="display:none;"><i class="ri-error-warning-line"></i><span id="setupErrorText"></span></div>
+      <div class="form-group">
+        <label class="form-label">Pharmacy name <span style="color:var(--accent);">*</span></label>
+        <input type="text" class="form-input" id="setupName" placeholder="e.g. Apollo Pharmacy">
+      </div>
+      <div class="form-group">
+        <label class="form-label">Address <span style="color:var(--accent);">*</span></label>
+        <input type="text" class="form-input" id="setupAddress" placeholder="e.g. 5th Block, Koramangala">
+      </div>
+      <div class="form-group">
+        <label class="form-label">Area <span style="color:var(--accent);">*</span></label>
+        <input type="text" class="form-input" id="setupArea" placeholder="e.g. Koramangala">
+      </div>
+      <div class="form-group" style="margin-bottom:24px;">
+        <label class="form-label">Phone number <span style="color:var(--accent);">*</span></label>
+        <input type="tel" class="form-input" id="setupPhone" placeholder="e.g. 080-41234567">
+      </div>
+      <div style="display:flex;gap:10px;">
+        <button class="btn btn-primary" id="setupSaveBtn" onclick="savePharmacySetup()"><i class="ri-save-line"></i> Save & Continue</button>
+        <button class="btn btn-outline" onclick="document.getElementById('setupModal').style.display='none'">Cancel</button>
+      </div>
     </div>
-    <div class="sc-content">
-        <div class="stats-row">
-            <div class="stat-card"><div class="stat-icon si-amber"><i class="ri-time-line"></i></div><div class="stat-label">Pending</div><div class="stat-val">3</div><div class="stat-sub">Needs attention</div></div>
-            <div class="stat-card"><div class="stat-icon si-blue"><i class="ri-checkbox-circle-line"></i></div><div class="stat-label">Confirmed</div><div class="stat-val">2</div><div class="stat-sub">Being prepared</div></div>
-            <div class="stat-card"><div class="stat-icon si-green"><i class="ri-store-line"></i></div><div class="stat-label">Ready</div><div class="stat-val">1</div><div class="stat-sub">Awaiting pickup</div></div>
-            <div class="stat-card"><div class="stat-icon si-gray"><i class="ri-archive-line"></i></div><div class="stat-label">Today's total</div><div class="stat-val">12</div><div class="stat-sub">Orders processed</div></div>
-        </div>
-        <div class="search-filter-row">
-            <div class="sc-search"><i class="ri-search-line" style="color:var(--text-muted);flex-shrink:0;"></i><input type="text" placeholder="Search by patient or medicine..."></div>
-            <button class="filter-btn"><i class="ri-filter-line"></i> Filter</button>
-            <button class="filter-btn"><i class="ri-sort-asc"></i> Sort: Newest</button>
-        </div>
-        <div class="tabs">
-            <button class="tab active" onclick="setTab(this,'all')">All</button>
-            <button class="tab" onclick="setTab(this,'pending')">Pending</button>
-            <button class="tab" onclick="setTab(this,'confirmed')">Confirmed</button>
-            <button class="tab" onclick="setTab(this,'ready')">Ready</button>
-        </div>
-        <div id="orders-list">
-            <a href="order-detail.html" class="order-card urgent">
-                <div class="ord-icon"><i class="ri-user-line"></i></div>
-                <div><div class="ord-patient">Ravi Kumar · Type 2</div><div class="ord-meds">Metformin 500mg × 30, Glimepiride 1mg × 15</div><div class="ord-meta"><span><i class="ri-time-line"></i> Evening pickup</span><span><i class="ri-attachment-line"></i> Prescription attached</span></div></div>
-                <div class="ord-time">Just now</div>
-                <span class="badge status-pending">Pending</span>
-            </a>
-            <a href="order-detail.html" class="order-card">
-                <div class="ord-icon"><i class="ri-user-line"></i></div>
-                <div><div class="ord-patient">Priya Sharma · Type 1</div><div class="ord-meds">Insulin Glargine 100IU × 2 vials</div><div class="ord-meta"><span><i class="ri-time-line"></i> Morning pickup</span><span><i class="ri-attachment-line"></i> Prescription attached</span></div></div>
-                <div class="ord-time">15 min ago</div>
-                <span class="badge status-pending">Pending</span>
-            </a>
-            <a href="order-detail.html" class="order-card">
-                <div class="ord-icon" style="background:#DBEAFE;color:#1E40AF;"><i class="ri-user-line"></i></div>
-                <div><div class="ord-patient">Arun Mehta · Type 2</div><div class="ord-meds">Sitagliptin 100mg × 30</div><div class="ord-meta"><span><i class="ri-time-line"></i> Afternoon pickup</span></div></div>
-                <div class="ord-time">1h ago</div>
-                <span class="badge status-confirmed">Confirmed</span>
-            </a>
-            <a href="order-detail.html" class="order-card">
-                <div class="ord-icon" style="background:#D1FAE5;color:#065F46;"><i class="ri-user-line"></i></div>
-                <div><div class="ord-patient">Meena Nair · Caregiver</div><div class="ord-meds">Metformin 1000mg × 60, Atorvastatin 10mg × 30</div><div class="ord-meta"><span><i class="ri-time-line"></i> Evening pickup</span></div></div>
-                <div class="ord-time">3h ago</div>
-                <span class="badge status-ready">Ready</span>
-            </a>
-        </div>
-    </div>
-</div>
-<script>
-function setTab(el,tab){
-    document.querySelectorAll('.tab').forEach(t=>t.classList.remove('active'));
-    el.classList.add('active');
-}
-</script>
- <script src="../js/env.js"></script>
+  </div>
+
+  <script>
+    let currentFilter='all';
+    function filterTab(el,status){document.querySelectorAll('.tab').forEach(t=>t.classList.remove('active'));el.classList.add('active');currentFilter=status;applyFilters();}
+    function filterSearch(val){applyFilters(val);}
+    function applyFilters(search=''){
+      const sv=search.toLowerCase();
+      document.querySelectorAll('.order-card').forEach(c=>{
+        // Hide collected and cancelled from 'all' tab — only show when explicitly selected
+        const hiddenInAll = currentFilter === 'all' && (c.dataset.status === 'collected' || c.dataset.status === 'cancelled');
+        const statusOk = !hiddenInAll && (currentFilter === 'all' || c.dataset.status === currentFilter);
+        const textOk = !sv || c.textContent.toLowerCase().includes(sv);
+        c.style.display = (statusOk && textOk) ? 'flex' : 'none';
+      });
+    }
+  </script>
+  <script src="../js/env.js"></script>
   <script type="module">
-    import { logOut, requireAuth } from '../js/auth.js';
+    import { requireAuth, logOut }                                from '../js/auth.js';
+    import { getPharmacyProfile, listenToPharmacyOrders,
+             getStatusLabel, getStatusClass, getOrderCounts,
+             registerPharmacy }                                  from '../js/pharmacy.js';
+
+    window.savePharmacySetup = async () => {
+      const name    = document.getElementById('setupName').value.trim();
+      const address = document.getElementById('setupAddress').value.trim();
+      const area    = document.getElementById('setupArea').value.trim();
+      const phone   = document.getElementById('setupPhone').value.trim();
+      const errorEl = document.getElementById('setupError');
+      const errorTx = document.getElementById('setupErrorText');
+      const saveBtn = document.getElementById('setupSaveBtn');
+
+      errorEl.style.display = 'none';
+
+      if (!name || !address || !area || !phone) {
+        errorEl.style.display = 'flex';
+        errorTx.textContent   = 'Please fill in all fields.';
+        return;
+      }
+
+      saveBtn.textContent = 'Saving...';
+      saveBtn.disabled    = true;
+
+      try {
+        await registerPharmacy(window.__currentUserId, name, address, area, phone);
+        document.getElementById('setupModal').style.display = 'none';
+        window.location.reload();
+      } catch (err) {
+        console.error('Setup failed:', err);
+        errorEl.style.display = 'flex';
+        errorTx.textContent   = 'Setup failed: ' + err.message;
+        saveBtn.textContent   = 'Save & Continue';
+        saveBtn.disabled      = false;
+      }
+    };
+
     window.logOut = logOut;
-</script>
-</body></html>
+
+    requireAuth(async (profile) => {
+      if (profile.role !== 'pharmacy') {
+        window.location.href = '../patient/dashboard.html';
+        return;
+      }
+
+      window.__currentUserId = profile.uid;
+
+      let pharmacy;
+      try {
+        pharmacy = await getPharmacyProfile(profile.uid);
+      } catch (err) {
+        document.getElementById('pharmacyName').textContent = profile.name || 'Pharmacy';
+        document.getElementById('ordersList').innerHTML = `
+          <div class="empty-state" style="display:flex;flex-direction:column;align-items:center;">
+            <i class="ri-store-2-line" style="font-size:48px;color:var(--border);margin-bottom:16px;"></i>
+            <h3 style="margin-bottom:8px;">Pharmacy not set up</h3>
+            <p style="margin-bottom:20px;">Your account is not linked to a pharmacy yet.</p>
+            <button class="btn btn-primary" onclick="document.getElementById('setupModal').style.display='flex'">
+              <i class="ri-store-2-line"></i> Set Up Pharmacy
+            </button>
+          </div>`;
+        return;
+      }
+
+      document.getElementById('pharmacyName').textContent = pharmacy.name;
+
+      listenToPharmacyOrders(pharmacy.id, (orders) => {
+        const counts = getOrderCounts(orders);
+
+        document.getElementById('pendingCount').textContent   = counts.pending;
+        document.getElementById('confirmedCount').textContent = counts.confirmed;
+        document.getElementById('readyCount').textContent     = counts.ready;
+        document.getElementById('collectedCount').textContent = counts.collected;
+
+        // Show notif dot if there are pending orders
+        const notifDot = document.getElementById('notifDot');
+        if (notifDot) notifDot.style.display = counts.pending > 0 ? 'block' : 'none';
+
+        const list  = document.getElementById('ordersList');
+        const empty = document.getElementById('emptyState');
+
+        if (orders.length === 0) {
+          list.innerHTML = '';
+          empty.style.display = 'flex';
+          return;
+        }
+        empty.style.display = 'none';
+        list.innerHTML = '';
+
+        orders.forEach(r => {
+          const meds  = r.medicines?.map(m => `${m.name} ×${m.quantity}`).join(', ') || '—';
+          const label = getStatusLabel(r.status);
+          const cls   = getStatusClass(r.status);
+          const date  = r.createdAt?.toDate().toLocaleDateString('en-IN') || '';
+
+          const iconMap = {
+            pending:   'ri-time-line',
+            confirmed: 'ri-check-line',
+            ready:     'ri-checkbox-circle-line',
+            collected: 'ri-archive-line',
+            cancelled: 'ri-close-circle-line'
+          };
+
+          const card = document.createElement('a');
+          card.href           = `order-detail.html?id=${r.id}`;
+          card.className      = 'order-card';
+          card.dataset.status = r.status;
+          card.innerHTML      = `
+            <div class="order-icon"><i class="ri-user-heart-line"></i></div>
+            <div class="order-main">
+              <div class="order-patient">${r.patientName || 'Patient'}</div>
+              <div class="order-meds">${meds}</div>
+              <div class="order-time">Pickup: ${r.preferredPickupTime || '—'} &middot; ${date}</div>
+            </div>
+            <div class="order-right">
+              <span class="${cls}"><i class="${iconMap[r.status] || 'ri-question-line'}"></i> ${label}</span>
+              ${r.status === 'pending' ? '<span class="new-badge">NEW</span>' : ''}
+            </div>`;
+          list.appendChild(card);
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/pharmacy/order-detail.html
+++ b/pharmacy/order-detail.html
@@ -1,140 +1,240 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ShareCare — Order Detail</title>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/remixicon/4.6.0/remixicon.min.css" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400&family=DM+Serif+Display:ital@0;1&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="../assets/style.css">
-    <style>
-        body{display:flex;}
-        .detail-layout{display:grid;grid-template-columns:1fr 280px;gap:24px;max-width:960px;}
-        .detail-card{background:var(--card);border-radius:20px;padding:28px;border:1px solid var(--border);margin-bottom:16px;}
-        .medicine-table{width:100%;border-collapse:collapse;}
-        .medicine-table th{font-size:0.75rem;font-weight:700;text-transform:uppercase;letter-spacing:0.05em;color:var(--text-muted);text-align:left;padding:10px 0;border-bottom:1px solid var(--border);}
-        .medicine-table td{padding:12px 0;border-bottom:1px solid var(--border);font-size:0.875rem;}
-        .medicine-table tr:last-child td{border-bottom:none;}
-        .avail-toggle{display:flex;gap:8px;}
-        .avail-btn{padding:5px 12px;border-radius:999px;border:1.5px solid var(--border);font-size:0.78rem;font-weight:600;cursor:pointer;font-family:var(--font-body);transition:all 0.2s;background:var(--card);color:var(--text-muted);}
-        .avail-btn.yes.selected{border-color:#16A34A;background:#F0FDF4;color:#16A34A;}
-        .avail-btn.no.selected{border-color:#DC2626;background:#FEF2F2;color:#DC2626;}
-        .status-actions{display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-top:20px;}
-        .action-card{border:1.5px solid var(--border);border-radius:14px;padding:18px;cursor:pointer;transition:all 0.2s;text-align:center;}
-        .action-card:hover{transform:translateY(-2px);}
-        .action-card.confirm:hover{border-color:#3B82F6;background:#EFF6FF;}
-        .action-card.ready:hover{border-color:#16A34A;background:#F0FDF4;}
-        .action-card.collected:hover{border-color:var(--primary);background:var(--primary-light);}
-        .action-card.reject:hover{border-color:#DC2626;background:#FEF2F2;}
-        .action-card i{font-size:1.5rem;display:block;margin-bottom:8px;color:var(--text-muted);}
-        .action-card.confirm i{color:#3B82F6;}
-        .action-card.ready i{color:#16A34A;}
-        .action-card.collected i{color:var(--primary);}
-        .action-card.reject i{color:#DC2626;}
-        .action-card span{font-size:0.82rem;font-weight:600;color:var(--text);}
-        .action-card small{display:block;font-size:0.72rem;color:var(--text-muted);margin-top:3px;}
-        .side-card{background:var(--card);border-radius:16px;padding:20px;border:1px solid var(--border);margin-bottom:14px;}
-        .side-title{font-size:0.875rem;font-weight:700;margin-bottom:12px;}
-        .info-row{display:flex;justify-content:space-between;align-items:center;padding:9px 0;border-bottom:1px solid var(--border);font-size:0.82rem;}
-        .info-row:last-child{border-bottom:none;}
-        .info-label{color:var(--text-muted);}
-        .notes-input{width:100%;padding:10px 12px;border:1.5px solid var(--border);border-radius:10px;font-family:var(--font-body);font-size:0.875rem;resize:none;height:80px;outline:none;transition:border-color 0.2s;}
-        .notes-input:focus{border-color:var(--primary);}
-    </style>
+  <meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ShareCare — Order Detail</title>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/remixicon/4.6.0/remixicon.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="../assets/style.css">
+  <style>
+    /* === CRITICAL LAYOUT === */
+    html,body{margin:0;padding:0;}
+
+    .detail-grid{display:grid;grid-template-columns:1fr 300px;gap:24px;align-items:start;}
+    .detail-card{background:var(--card);border-radius:var(--radius-xl);padding:36px;border:1px solid var(--border-light);}
+    .detail-header{display:flex;align-items:flex-start;justify-content:space-between;margin-bottom:24px;padding-bottom:20px;border-bottom:1px solid var(--border-light);}
+    .patient-chip{display:flex;align-items:center;gap:12px;}
+    .patient-avatar{width:48px;height:48px;background:var(--accent-light);border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:20px;color:var(--accent-dark);}
+    .patient-name{font-size:16px;font-weight:700;}
+    .patient-sub{font-size:13px;color:var(--text-muted);}
+    .med-table{width:100%;border-collapse:collapse;margin-top:8px;}
+    .med-table th{font-size:12px;color:var(--text-muted);font-weight:600;text-transform:uppercase;letter-spacing:0.05em;padding:8px 12px;text-align:left;background:var(--bg);border-radius:var(--radius-sm);}
+    .med-table td{padding:12px 12px;font-size:14px;border-bottom:1px solid var(--border-light);}
+    .med-table tr:last-child td{border-bottom:none;}
+    .info-row{display:flex;gap:12px;padding:14px 0;border-bottom:1px solid var(--border-light);}
+    .info-row:last-child{border-bottom:none;}
+    .info-icon{width:36px;height:36px;background:var(--primary-light);color:var(--primary);border-radius:var(--radius-sm);display:flex;align-items:center;justify-content:center;font-size:17px;flex-shrink:0;margin-top:2px;}
+    .info-label{font-size:12px;color:var(--text-muted);font-weight:600;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:4px;}
+    .info-val{font-size:14px;font-weight:500;}
+    /* Action panel */
+    .action-panel{background:var(--card);border-radius:var(--radius-xl);padding:24px;border:1px solid var(--border-light);margin-bottom:16px;}
+    .action-panel h3{font-family:'DM Serif Display',serif;font-size:17px;margin-bottom:16px;}
+    .action-btns{display:flex;flex-direction:column;gap:10px;}
+    .notes-field{width:100%;padding:10px 14px;border:1.5px solid var(--border);border-radius:var(--radius-md);font-family:'DM Sans',sans-serif;font-size:14px;resize:none;min-height:80px;outline:none;transition:border-color 0.2s;background:var(--bg);}
+    .notes-field:focus{border-color:var(--primary);background:white;}
+    .presc-img{width:100%;border-radius:var(--radius-md);border:1px solid var(--border);cursor:pointer;margin-top:8px;}
+    .history-item{display:flex;gap:10px;padding:10px 0;border-bottom:1px solid var(--border-light);font-size:13px;}
+    .history-item:last-child{border-bottom:none;}
+    .history-item i{color:var(--primary);margin-top:2px;}
+  </style>
 </head>
 <body>
-<aside class="sc-sidebar">
-    <a href="../index.html" class="sc-logo"><i class="ri-heart-pulse-fill"></i> ShareCare</a>
-    <ul class="sc-sidebar-nav">
-        <li><a href="dashboard.html" class="sc-sidebar-item active"><i class="ri-dashboard-line"></i> Orders</a></li>
-        <li><a href="#" class="sc-sidebar-item"><i class="ri-notification-3-line"></i> Notifications <span class="sc-nav-badge">3</span></a></li>
-        <li><a href="#" class="sc-sidebar-item"><i class="ri-settings-4-line"></i> Settings</a></li>
-    </ul>
-    <div class="sc-sidebar-footer">
+  <div class="sc-app">
+    <aside class="sc-sidebar">
+      <a href="../index.html" class="sc-logo"><i class="ri-heart-pulse-fill"></i> ShareCare</a>
+      <div class="sc-sidebar-section">Pharmacy</div>
+      <ul class="sc-sidebar-menu">
+        <li><a href="dashboard.html" class="sc-sidebar-item active"><i class="ri-dashboard-line"></i> All Orders</a></li>
+      </ul>
+      <div class="sc-sidebar-footer">
         <div class="sc-user-chip">
-            <img src="https://images.unsplash.com/photo-1576091160550-2173dba999ef?w=80&auto=format&fit=crop" alt="Pharmacy">
-            <div><div class="sc-user-chip-name">Apollo Pharmacy</div><div class="sc-user-chip-role">Koramangala</div></div>
-            <i class="ri-logout-box-r-line"></i>
+          <img src="https://images.unsplash.com/photo-1560250097-0b93528c311a?w=80&q=80" alt="Pharmacy">
+          <div><div class="sc-user-name" id="pharmacyName">Pharmacy</div><div class="sc-user-role">Pharmacy</div></div>
+          <i class="ri-logout-box-r-line sc-logout" onclick="logOut()"></i>
         </div>
-    </div>
-</aside>
-<div class="sc-main">
-    <div class="sc-topbar">
-        <div style="display:flex;align-items:center;gap:12px;">
-            <a href="dashboard.html" style="display:flex;align-items:center;gap:6px;font-size:0.82rem;color:var(--text-muted);text-decoration:none;"><i class="ri-arrow-left-line"></i> Back</a>
-            <div><div class="sc-topbar-title">Order #SC-2024-008</div><div class="sc-topbar-sub">Ravi Kumar · Received just now</div></div>
+      </div>
+    </aside>
+    <div class="sc-main">
+      <div class="sc-topbar">
+        <div><div class="sc-topbar-title" id="pageTitle">Order Detail</div><div class="sc-topbar-sub" id="pageSub">Manage this medicine request</div></div>
+        <div class="sc-topbar-right">
+          <a href="dashboard.html" class="btn btn-outline btn-sm"><i class="ri-arrow-left-line"></i> All Orders</a>
         </div>
-        <span class="badge status-pending" style="padding:6px 14px;font-size:0.8rem;">Pending</span>
-    </div>
-    <div class="sc-content">
-        <div class="detail-layout">
-            <div>
-                <div class="detail-card">
-                    <h3 style="font-family:var(--font-display);font-size:1.1rem;margin-bottom:16px;">Medicines requested</h3>
-                    <table class="medicine-table">
-                        <thead><tr><th>Medicine</th><th>Qty</th><th>Availability</th></tr></thead>
-                        <tbody>
-                            <tr>
-                                <td><strong>Metformin 500mg</strong></td>
-                                <td>30 tablets</td>
-                                <td><div class="avail-toggle"><button class="avail-btn yes selected" onclick="setAvail(this,'yes')">In stock</button><button class="avail-btn no" onclick="setAvail(this,'no')">Out of stock</button></div></td>
-                            </tr>
-                            <tr>
-                                <td><strong>Glimepiride 1mg</strong></td>
-                                <td>15 tablets</td>
-                                <td><div class="avail-toggle"><button class="avail-btn yes selected" onclick="setAvail(this,'yes')">In stock</button><button class="avail-btn no" onclick="setAvail(this,'no')">Out of stock</button></div></td>
-                            </tr>
-                        </tbody>
-                    </table>
+      </div>
+      <div class="sc-content">
+        <div class="detail-grid" id="detailContent" style="display:none;">
+          <div>
+            <div class="detail-card" style="margin-bottom:20px;">
+              <div class="detail-header">
+                <div class="patient-chip">
+                  <div class="patient-avatar"><i class="ri-user-line"></i></div>
+                  <div><div class="patient-name" id="patientName">—</div><div class="patient-sub" id="requestDate">—</div></div>
                 </div>
-                <div class="detail-card">
-                    <h3 style="font-family:var(--font-display);font-size:1.1rem;margin-bottom:16px;">Update order status</h3>
-                    <div class="status-actions">
-                        <div class="action-card confirm" onclick="updateStatus('confirmed')"><i class="ri-checkbox-circle-line"></i><span>Confirm order</span><small>Mark as accepted</small></div>
-                        <div class="action-card ready" onclick="updateStatus('ready')"><i class="ri-store-line"></i><span>Mark as ready</span><small>Ready for pickup</small></div>
-                        <div class="action-card collected" onclick="updateStatus('collected')"><i class="ri-check-double-line"></i><span>Mark collected</span><small>Patient picked up</small></div>
-                        <div class="action-card reject" onclick="updateStatus('rejected')"><i class="ri-close-circle-line"></i><span>Reject order</span><small>Cannot fulfil</small></div>
-                    </div>
-                    <div style="margin-top:16px;">
-                        <label style="font-size:0.82rem;font-weight:600;display:block;margin-bottom:7px;">Add note to patient (optional)</label>
-                        <textarea class="notes-input" placeholder="e.g. Glimepiride will be available by 4pm today..."></textarea>
-                        <button class="btn btn-primary" style="margin-top:10px;width:100%;justify-content:center;" onclick="saveNote()"><i class="ri-save-line"></i> Save note</button>
-                    </div>
+                <div>
+                  <div id="statusBadge"></div>
+              </div>
+              <div id="deliveryBadge" style="display:none;">
+                <span class="delivery-badge"><i class="ri-e-bike-line"></i> Delivery Requested</span>
+                  <div id="deliveryBadge" style="display:none;" class="delivery-badge"><i class="ri-e-bike-line"></i> Delivery Requested</div>
                 </div>
+              </div>
+              <div style="margin-bottom:20px;">
+                <div style="font-size:13px;font-weight:600;color:var(--text-muted);margin-bottom:10px;">MEDICINES REQUESTED</div>
+                <table class="med-table"><thead><tr><th>Medicine</th><th>Quantity</th></tr></thead><tbody id="medTableBody"></tbody></table>
+              </div>
+              <div class="info-row">
+                <div class="info-icon"><i class="ri-time-line"></i></div>
+                <div><div class="info-label">Preferred Pickup</div><div class="info-val" id="rPickup">—</div></div>
+              </div>
+              <div class="info-row" id="rNotesRow" style="display:none;">
+                <div class="info-icon"><i class="ri-message-3-line"></i></div>
+                <div><div class="info-label">Patient Notes</div><div class="info-val" id="rNotes">—</div></div>
+              </div>
             </div>
-            <div>
-                <div class="side-card">
-                    <div class="side-title">Patient info</div>
-                    <div class="info-row"><span class="info-label">Name</span><span style="font-weight:600;">Ravi Kumar</span></div>
-                    <div class="info-row"><span class="info-label">Type</span><span>Type 2 Diabetic</span></div>
-                    <div class="info-row"><span class="info-label">Pickup</span><span>Evening (4–8pm)</span></div>
-                    <div class="info-row"><span class="info-label">Submitted</span><span>Just now</span></div>
-                </div>
-                <div class="side-card">
-                    <div class="side-title">Prescription</div>
-                    <img src="https://images.unsplash.com/photo-1550831107-1553da8c8464?w=260&auto=format&fit=crop" style="width:100%;border-radius:10px;border:1px solid var(--border);" alt="Prescription">
-                    <a href="#" style="display:flex;align-items:center;gap:6px;font-size:0.78rem;color:var(--primary);text-decoration:none;margin-top:10px;font-weight:600;"><i class="ri-eye-line"></i> View full size</a>
-                </div>
-                <div class="disclaimer"><i class="ri-information-fill"></i><span>Verify prescription before confirming any controlled medicines.</span></div>
+            <div class="detail-card" id="prescCard" style="display:none;">
+              <div style="font-size:13px;font-weight:600;color:var(--text-muted);margin-bottom:4px;">PRESCRIPTION</div>
+              <img id="prescImg" class="presc-img" alt="Prescription">
             </div>
+          </div>
+          <div>
+            <div class="action-panel">
+              <h3>Update Order Status</h3>
+              <div class="action-btns">
+                <button class="btn btn-primary w-full" id="actionBtn" style="display:none;justify-content:center;"></button>
+                <button class="btn btn-danger w-full" id="cancelBtn" style="display:none;justify-content:center;"><i class="ri-close-circle-line"></i> Cancel Order</button>
+              </div>
+              <div style="margin-top:20px;">
+                <label style="font-size:13px;font-weight:600;color:var(--text);display:block;margin-bottom:7px;">Add note to patient</label>
+                <textarea class="notes-field" id="pharmacyNotes" placeholder="e.g. Medicine arriving by evening, please collect after 6pm..."></textarea>
+                <button class="btn btn-primary w-full" style="margin-top:10px;" onclick="saveNotes()"><i class="ri-save-line"></i> Save Note</button>
+              </div>
+            </div>
+            <div class="action-panel">
+              <h3>Status History</h3>
+              <div id="historyList"><div style="font-size:13px;color:var(--text-muted);">No history yet.</div></div>
+            </div>
+          </div>
         </div>
+        <div id="loadingState" class="empty-state"><i class="ri-loader-4-line"></i><h3>Loading order...</h3></div>
+      </div>
     </div>
-</div>
-<script>
-function setAvail(btn,val){
-    const btns=btn.closest('.avail-toggle').querySelectorAll('.avail-btn');
-    btns.forEach(b=>{b.classList.remove('selected');});
-    btn.classList.add('selected');
-}
-function updateStatus(status){
-    const labels={confirmed:'Confirmed',ready:'Ready for Pickup',collected:'Collected',rejected:'Rejected'};
-    const statusEl=document.querySelector('.sc-topbar .badge');
-    statusEl.textContent=labels[status];
-    statusEl.className='badge';
-    if(status==='confirmed')statusEl.classList.add('status-confirmed');
-    else if(status==='ready')statusEl.classList.add('status-ready');
-    else if(status==='collected')statusEl.classList.add('status-collected');
-    else statusEl.style.cssText='background:#FEF2F2;color:#DC2626;padding:6px 14px;font-size:0.8rem;border-radius:999px;font-weight:600;';
-}
-function saveNote(){const ta=document.querySelector('.notes-input');if(ta.value.trim()){alert('Note saved and patient has been notified.');ta.value='';}}
-</script>
-</body></html>
+  </div>
+  <script src="../js/env.js"></script>
+  <script type="module">
+    import { requireAuth, logOut }                                        from '../js/auth.js';
+    import { getPharmacyProfile, listenToOrder,
+             updateOrderStatus, getStatusLabel, getStatusClass,
+             getNextStatus, getNextStatusLabel }                          from '../js/pharmacy.js';
+    import { db }                                                         from '../js/firebase-config.js';
+    import { doc, updateDoc, serverTimestamp }                            from 'https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore.js';
+
+    window.logOut = logOut;
+
+    const id = new URLSearchParams(location.search).get('id');
+
+    const statusIconMap = {
+      pending:   'ri-time-line',
+      confirmed: 'ri-check-line',
+      ready:     'ri-checkbox-circle-line',
+      collected: 'ri-archive-line',
+      cancelled: 'ri-close-circle-line'
+    };
+
+    requireAuth(async (profile) => {
+      if (profile.role !== 'pharmacy') {
+        window.location.href = '../patient/dashboard.html';
+        return;
+      }
+
+      let pharmacy;
+      try {
+        pharmacy = await getPharmacyProfile(profile.uid);
+      } catch (err) {
+        document.getElementById('pharmacyName').textContent = profile.name || 'Pharmacy';
+      }
+      if (pharmacy) document.getElementById('pharmacyName').textContent = pharmacy.name;
+
+      if (!id) return;
+
+      listenToOrder(id, (r) => {
+        document.getElementById('loadingState').style.display  = 'none';
+        document.getElementById('detailContent').style.display = 'grid';
+
+        const label = getStatusLabel(r.status);
+        const cls   = getStatusClass(r.status);
+        const icon  = statusIconMap[r.status] || 'ri-question-line';
+
+        document.getElementById('patientName').textContent    = r.patientName || 'Patient';
+        document.getElementById('requestDate').textContent    = `Submitted ${r.createdAt?.toDate().toLocaleDateString('en-IN', { day: 'numeric', month: 'short', year: 'numeric' }) || ''}`;
+        document.getElementById('pageTitle').textContent      = `Order — ${r.patientName || 'Patient'}`;
+        document.getElementById('statusBadge').innerHTML      = `<span class="${cls}"><i class="${icon}"></i> ${label}</span>`;
+        document.getElementById('rPickup').textContent        = r.preferredPickupTime || '—';
+
+        if (r.notes)         { document.getElementById('rNotesRow').style.display = 'flex'; document.getElementById('rNotes').textContent = r.notes; }
+        if (r.pharmacyNotes) document.getElementById('pharmacyNotes').value = r.pharmacyNotes;
+
+        // Medicine table
+        const tbody = document.getElementById('medTableBody');
+        tbody.innerHTML = '';
+        r.medicines?.forEach(m => { tbody.innerHTML += `<tr><td>${m.name}</td><td>${m.quantity}</td></tr>`; });
+
+        // Update action button based on current status
+        const nextStatus = getNextStatus(r.status);
+        const nextLabel  = getNextStatusLabel(r.status);
+        const actionBtn  = document.getElementById('actionBtn');
+        const cancelBtn  = document.getElementById('cancelBtn');
+
+        const iconMap2 = {
+          'Confirm Order':       'ri-check-line',
+          'Mark as Ready':       'ri-checkbox-circle-line',
+          'Mark as Collected':   'ri-archive-line',
+          'Mark as Dispatched':  'ri-send-plane-line'
+        };
+
+        // Show delivery badge if patient requested delivery
+        const deliveryBadge = document.getElementById('deliveryBadge');
+        if (deliveryBadge) {
+          deliveryBadge.style.display = r.deliveryPreference === 'delivery' ? 'inline-flex' : 'none';
+        }
+
+        if (actionBtn) {
+          if (nextStatus) {
+            // If status is ready and patient chose delivery, change label to Dispatched
+            const displayLabel = (r.status === 'ready' && r.deliveryPreference === 'delivery')
+              ? 'Mark as Dispatched'
+              : nextLabel;
+            actionBtn.style.display  = 'inline-flex';
+            actionBtn.innerHTML      = `<i class="${iconMap2[displayLabel] || 'ri-arrow-right-line'}"></i> ${displayLabel}`;
+            actionBtn.onclick        = () => handleStatusUpdate(nextStatus);
+          } else {
+            actionBtn.style.display = 'none';
+          }
+        }
+
+        if (cancelBtn) {
+          cancelBtn.style.display = ['pending', 'confirmed'].includes(r.status) ? 'inline-flex' : 'none';
+          cancelBtn.onclick = () => handleStatusUpdate('cancelled');
+        }
+      });
+    });
+
+    async function handleStatusUpdate(newStatus) {
+      if (!id) return;
+      const notes = document.getElementById('pharmacyNotes')?.value || '';
+      try {
+        await updateOrderStatus(id, newStatus, notes);
+      } catch (err) {
+        alert(err.message);
+      }
+    }
+
+    window.saveNotes = async () => {
+      if (!id) return;
+      const notes = document.getElementById('pharmacyNotes').value;
+      await updateDoc(doc(db, 'requests', id), {
+        pharmacyNotes: notes,
+        updatedAt:     serverTimestamp()
+      });
+    };
+  </script>
+</body>
+</html>

--- a/scripts/build-env.js
+++ b/scripts/build-env.js
@@ -1,26 +1,32 @@
 /**
  * build-env.js
- * Runs at Vercel build time to generate js/env.js from environment variables.
- * This is needed because env.js is gitignored and never committed.
+ * Generates js/env.js from Vercel environment variables at build time.
+ * 
+ * VERCEL_ENV is set automatically by Vercel:
+ *   - 'production' → uses PROD_FIREBASE_* variables
+ *   - 'preview'    → uses DEV_FIREBASE_* variables
  */
 
 const fs   = require('fs');
 const path = require('path');
 
-const {
-  PROD_FIREBASE_API_KEY,
-  PROD_FIREBASE_AUTH_DOMAIN,
-  PROD_FIREBASE_PROJECT_ID,
-  PROD_FIREBASE_MESSAGING_SENDER_ID,
-  PROD_FIREBASE_APP_ID
-} = process.env;
+const env    = process.env.VERCEL_ENV || 'preview';
+const prefix = env === 'production' ? 'PROD' : 'DEV';
+
+console.log(`Building env.js for Vercel environment: ${env} (using ${prefix}_FIREBASE_* variables)`);
+
+const API_KEY             = process.env[`${prefix}_FIREBASE_API_KEY`];
+const AUTH_DOMAIN         = process.env[`${prefix}_FIREBASE_AUTH_DOMAIN`];
+const PROJECT_ID          = process.env[`${prefix}_FIREBASE_PROJECT_ID`];
+const MESSAGING_SENDER_ID = process.env[`${prefix}_FIREBASE_MESSAGING_SENDER_ID`];
+const APP_ID              = process.env[`${prefix}_FIREBASE_APP_ID`];
 
 const missing = [
-  'PROD_FIREBASE_API_KEY',
-  'PROD_FIREBASE_AUTH_DOMAIN',
-  'PROD_FIREBASE_PROJECT_ID',
-  'PROD_FIREBASE_MESSAGING_SENDER_ID',
-  'PROD_FIREBASE_APP_ID'
+  `${prefix}_FIREBASE_API_KEY`,
+  `${prefix}_FIREBASE_AUTH_DOMAIN`,
+  `${prefix}_FIREBASE_PROJECT_ID`,
+  `${prefix}_FIREBASE_MESSAGING_SENDER_ID`,
+  `${prefix}_FIREBASE_APP_ID`,
 ].filter(key => !process.env[key]);
 
 if (missing.length > 0) {
@@ -29,11 +35,11 @@ if (missing.length > 0) {
 }
 
 const content = `window.__env = {
-  FIREBASE_API_KEY:             "${PROD_FIREBASE_API_KEY}",
-  FIREBASE_AUTH_DOMAIN:         "${PROD_FIREBASE_AUTH_DOMAIN}",
-  FIREBASE_PROJECT_ID:          "${PROD_FIREBASE_PROJECT_ID}",
-  FIREBASE_MESSAGING_SENDER_ID: "${PROD_FIREBASE_MESSAGING_SENDER_ID}",
-  FIREBASE_APP_ID:              "${PROD_FIREBASE_APP_ID}"
+  FIREBASE_API_KEY:             "${API_KEY}",
+  FIREBASE_AUTH_DOMAIN:         "${AUTH_DOMAIN}",
+  FIREBASE_PROJECT_ID:          "${PROJECT_ID}",
+  FIREBASE_MESSAGING_SENDER_ID: "${MESSAGING_SENDER_ID}",
+  FIREBASE_APP_ID:              "${APP_ID}"
 };
 `;
 

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -173,3 +173,129 @@ describe('getStatusLabel', () => {
     expect(getStatusLabel('something_random')).toBe('Unknown');
   });
 });
+
+
+describe('validateEmail', () => {
+  function validateEmail(email) {
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+  }
+
+  test('accepts valid email', () => {
+    expect(validateEmail('ravi@example.com')).toBe(true);
+  });
+
+  test('accepts email with subdomain', () => {
+    expect(validateEmail('ravi@mail.example.com')).toBe(true);
+  });
+
+  test('rejects email without @', () => {
+    expect(validateEmail('raviexample.com')).toBe(false);
+  });
+
+  test('rejects email without domain', () => {
+    expect(validateEmail('ravi@')).toBe(false);
+  });
+
+  test('rejects email with spaces', () => {
+    expect(validateEmail('ravi @example.com')).toBe(false);
+  });
+
+  test('rejects empty string', () => {
+    expect(validateEmail('')).toBe(false);
+  });
+});
+
+
+describe('validatePassword', () => {
+  function validatePassword(password) {
+    if (password.length < 8) return 'Password must be at least 8 characters.';
+    if (!/(?=.*[a-zA-Z])(?=.*[0-9])/.test(password)) return 'Password must contain at least one letter and one number.';
+    return null;
+  }
+
+  test('accepts valid password with letters and numbers', () => {
+    expect(validatePassword('password123')).toBeNull();
+  });
+
+  test('accepts mixed case with numbers', () => {
+    expect(validatePassword('MyPass99')).toBeNull();
+  });
+
+  test('rejects password shorter than 8 chars', () => {
+    expect(validatePassword('pass1')).toBe('Password must be at least 8 characters.');
+  });
+
+  test('rejects password with only letters', () => {
+    expect(validatePassword('passwordonly')).toBe('Password must contain at least one letter and one number.');
+  });
+
+  test('rejects password with only numbers', () => {
+    expect(validatePassword('12345678')).toBe('Password must contain at least one letter and one number.');
+  });
+});
+
+
+describe('validateName', () => {
+  function validateName(name) {
+    return /^[a-zA-Z\s'-]{2,50}$/.test(name);
+  }
+
+  test('accepts simple name', () => {
+    expect(validateName('Ravi')).toBe(true);
+  });
+
+  test('accepts name with hyphen', () => {
+    expect(validateName('Mary-Jane')).toBe(true);
+  });
+
+  test('accepts name with apostrophe', () => {
+    expect(validateName("O'Brien")).toBe(true);
+  });
+
+  test('rejects single character name', () => {
+    expect(validateName('R')).toBe(false);
+  });
+
+  test('rejects name with numbers', () => {
+    expect(validateName('Ravi123')).toBe(false);
+  });
+
+  test('rejects name with special characters', () => {
+    expect(validateName('Ravi@Kumar')).toBe(false);
+  });
+
+  test('rejects empty string', () => {
+    expect(validateName('')).toBe(false);
+  });
+});
+
+
+describe('validatePhone', () => {
+  function validatePhone(phone) {
+    return /^[0-9\s\-\+\(\)]{7,15}$/.test(phone);
+  }
+
+  test('accepts standard phone number', () => {
+    expect(validatePhone('9876543210')).toBe(true);
+  });
+
+  test('accepts phone with dashes', () => {
+    expect(validatePhone('080-41234567')).toBe(true);
+  });
+
+  test('accepts phone with country code', () => {
+    expect(validatePhone('+91 9876543210')).toBe(true);
+  });
+
+  test('rejects phone with letters', () => {
+    expect(validatePhone('9876abc210')).toBe(false);
+  });
+
+  test('rejects phone too short', () => {
+    expect(validatePhone('123')).toBe(false);
+  });
+
+  test('rejects empty string', () => {
+    expect(validatePhone('')).toBe(false);
+  });
+});

--- a/tests/patient.test.js
+++ b/tests/patient.test.js
@@ -44,15 +44,29 @@ function canCancel(status) {
   return status === 'pending';
 }
 
-function buildRequestData(patientId, pharmacyId, medicines, notes, preferredPickupTime) {
+// Updated to include patientName and pharmacyName
+function buildRequestData(patientId, patientName, pharmacyId, pharmacyName, medicines, notes, preferredPickupTime) {
   return {
     patientId,
+    patientName,
     pharmacyId,
+    pharmacyName,
     medicines,
     notes,
     preferredPickupTime,
     status: 'pending'
   };
+}
+
+function isDeliveryAllowed() {
+  const hour = new Date().getHours();
+  return hour >= 9 && hour < 21;
+}
+
+function getDeliveryLabel(preference) {
+  if (preference === 'delivery') return 'Delivery requested — the pharmacy will dispatch your order.';
+  if (preference === 'pickup')   return 'You will pick up in person. Visit the pharmacy when your order is ready.';
+  return '';
 }
 
 
@@ -158,17 +172,83 @@ describe('canCancel', () => {
 
 describe('buildRequestData', () => {
   test('builds request with correct default status', () => {
-    const data = buildRequestData('uid1', 'pharm1', [{ name: 'Metformin', quantity: 1 }], '', 'Morning');
+    const data = buildRequestData('uid1', 'Ravi Kumar', 'pharm1', 'Apollo Pharmacy', [{ name: 'Metformin', quantity: 1 }], '', 'Morning');
     expect(data.status).toBe('pending');
     expect(data.patientId).toBe('uid1');
+    expect(data.patientName).toBe('Ravi Kumar');
     expect(data.pharmacyId).toBe('pharm1');
+    expect(data.pharmacyName).toBe('Apollo Pharmacy');
     expect(data.preferredPickupTime).toBe('Morning');
   });
 
   test('includes medicines array in request', () => {
     const meds = [{ name: 'Metformin', quantity: 2 }, { name: 'Glipizide', quantity: 1 }];
-    const data = buildRequestData('uid1', 'pharm1', meds, 'urgent', 'Evening');
+    const data = buildRequestData('uid1', 'Ravi Kumar', 'pharm1', 'Apollo Pharmacy', meds, 'urgent', 'Evening');
     expect(data.medicines).toHaveLength(2);
     expect(data.medicines[0].name).toBe('Metformin');
+  });
+
+  test('stores notes correctly', () => {
+    const data = buildRequestData('uid1', 'Ravi Kumar', 'pharm1', 'Apollo Pharmacy', [{ name: 'Metformin', quantity: 1 }], 'Please pack separately', 'Morning');
+    expect(data.notes).toBe('Please pack separately');
+  });
+});
+
+
+describe('isDeliveryAllowed', () => {
+  test('returns a boolean', () => {
+    expect(typeof isDeliveryAllowed()).toBe('boolean');
+  });
+
+  test('delivery is allowed between 9am and 9pm', () => {
+    // Mock hours within window
+    const originalDate = global.Date;
+    global.Date = class extends Date {
+      getHours() { return 14; } // 2 PM
+    };
+    expect(isDeliveryAllowed()).toBe(true);
+    global.Date = originalDate;
+  });
+
+  test('delivery is not allowed before 9am', () => {
+    const originalDate = global.Date;
+    global.Date = class extends Date {
+      getHours() { return 7; } // 7 AM
+    };
+    expect(isDeliveryAllowed()).toBe(false);
+    global.Date = originalDate;
+  });
+
+  test('delivery is not allowed after 9pm', () => {
+    const originalDate = global.Date;
+    global.Date = class extends Date {
+      getHours() { return 22; } // 10 PM
+    };
+    expect(isDeliveryAllowed()).toBe(false);
+    global.Date = originalDate;
+  });
+
+  test('delivery is not allowed exactly at 9pm', () => {
+    const originalDate = global.Date;
+    global.Date = class extends Date {
+      getHours() { return 21; } // 9 PM exactly
+    };
+    expect(isDeliveryAllowed()).toBe(false);
+    global.Date = originalDate;
+  });
+});
+
+
+describe('getDeliveryLabel', () => {
+  test('returns correct label for delivery preference', () => {
+    expect(getDeliveryLabel('delivery')).toBe('Delivery requested — the pharmacy will dispatch your order.');
+  });
+
+  test('returns correct label for pickup preference', () => {
+    expect(getDeliveryLabel('pickup')).toBe('You will pick up in person. Visit the pharmacy when your order is ready.');
+  });
+
+  test('returns empty string for unknown preference', () => {
+    expect(getDeliveryLabel('unknown')).toBe('');
   });
 });

--- a/tests/pharmacy.test.js
+++ b/tests/pharmacy.test.js
@@ -1,0 +1,289 @@
+/**
+ * pharmacy.test.js
+ * Unit tests for pure pharmacy helper logic.
+ */
+
+// ── Pure helpers (mirrors logic in pharmacy.js) ───────────────────────────────
+
+function getStatusLabel(status) {
+  const labels = {
+    pending:   'Pending',
+    confirmed: 'Confirmed',
+    ready:     'Ready for Pickup',
+    collected: 'Collected',
+    cancelled: 'Cancelled'
+  };
+  return labels[status] || 'Unknown';
+}
+
+function getStatusClass(status) {
+  const classes = {
+    pending:   'status-pending',
+    confirmed: 'status-confirmed',
+    ready:     'status-ready',
+    collected: 'status-collected',
+    cancelled: 'badge-danger'
+  };
+  return classes[status] || 'badge-gray';
+}
+
+function getNextStatus(currentStatus) {
+  const next = {
+    pending:   'confirmed',
+    confirmed: 'ready',
+    ready:     'collected'
+  };
+  return next[currentStatus] || null;
+}
+
+function getNextStatusLabel(currentStatus) {
+  const labels = {
+    pending:   'Confirm Order',
+    confirmed: 'Mark as Ready',
+    ready:     'Mark as Collected'
+  };
+  return labels[currentStatus] || null;
+}
+
+function getOrderCounts(orders) {
+  return {
+    total:     orders.length,
+    pending:   orders.filter(o => o.status === 'pending').length,
+    confirmed: orders.filter(o => o.status === 'confirmed').length,
+    ready:     orders.filter(o => o.status === 'ready').length,
+    collected: orders.filter(o => o.status === 'collected').length,
+    cancelled: orders.filter(o => o.status === 'cancelled').length
+  };
+}
+
+function isValidTransition(currentStatus, newStatus) {
+  const validTransitions = {
+    pending:   ['confirmed', 'cancelled'],
+    confirmed: ['ready',     'cancelled'],
+    ready:     ['collected'],
+    collected: [],
+    cancelled: []
+  };
+  return (validTransitions[currentStatus] || []).includes(newStatus);
+}
+
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('getStatusLabel', () => {
+  test('returns correct label for each status', () => {
+    expect(getStatusLabel('pending')).toBe('Pending');
+    expect(getStatusLabel('confirmed')).toBe('Confirmed');
+    expect(getStatusLabel('ready')).toBe('Ready for Pickup');
+    expect(getStatusLabel('collected')).toBe('Collected');
+    expect(getStatusLabel('cancelled')).toBe('Cancelled');
+  });
+
+  test('returns Unknown for unrecognised status', () => {
+    expect(getStatusLabel('other')).toBe('Unknown');
+  });
+});
+
+
+describe('getStatusClass', () => {
+  test('returns correct CSS class for each status', () => {
+    expect(getStatusClass('pending')).toBe('status-pending');
+    expect(getStatusClass('confirmed')).toBe('status-confirmed');
+    expect(getStatusClass('ready')).toBe('status-ready');
+    expect(getStatusClass('collected')).toBe('status-collected');
+    expect(getStatusClass('cancelled')).toBe('badge-danger');
+  });
+
+  test('returns badge-gray for unknown status', () => {
+    expect(getStatusClass('unknown')).toBe('badge-gray');
+  });
+});
+
+
+describe('getNextStatus', () => {
+  test('pending → confirmed', () => {
+    expect(getNextStatus('pending')).toBe('confirmed');
+  });
+
+  test('confirmed → ready', () => {
+    expect(getNextStatus('confirmed')).toBe('ready');
+  });
+
+  test('ready → collected', () => {
+    expect(getNextStatus('ready')).toBe('collected');
+  });
+
+  test('collected has no next status', () => {
+    expect(getNextStatus('collected')).toBeNull();
+  });
+
+  test('cancelled has no next status', () => {
+    expect(getNextStatus('cancelled')).toBeNull();
+  });
+});
+
+
+describe('getNextStatusLabel', () => {
+  test('returns correct action label for pending', () => {
+    expect(getNextStatusLabel('pending')).toBe('Confirm Order');
+  });
+
+  test('returns correct action label for confirmed', () => {
+    expect(getNextStatusLabel('confirmed')).toBe('Mark as Ready');
+  });
+
+  test('returns correct action label for ready', () => {
+    expect(getNextStatusLabel('ready')).toBe('Mark as Collected');
+  });
+
+  test('returns null for collected', () => {
+    expect(getNextStatusLabel('collected')).toBeNull();
+  });
+});
+
+
+describe('getOrderCounts', () => {
+  const orders = [
+    { status: 'pending' },
+    { status: 'pending' },
+    { status: 'confirmed' },
+    { status: 'ready' },
+    { status: 'collected' },
+    { status: 'cancelled' }
+  ];
+
+  test('counts total correctly', () => {
+    expect(getOrderCounts(orders).total).toBe(6);
+  });
+
+  test('counts pending correctly', () => {
+    expect(getOrderCounts(orders).pending).toBe(2);
+  });
+
+  test('counts confirmed correctly', () => {
+    expect(getOrderCounts(orders).confirmed).toBe(1);
+  });
+
+  test('counts ready correctly', () => {
+    expect(getOrderCounts(orders).ready).toBe(1);
+  });
+
+  test('counts collected correctly', () => {
+    expect(getOrderCounts(orders).collected).toBe(1);
+  });
+
+  test('counts cancelled correctly', () => {
+    expect(getOrderCounts(orders).cancelled).toBe(1);
+  });
+
+  test('returns zero counts for empty array', () => {
+    const counts = getOrderCounts([]);
+    expect(counts.total).toBe(0);
+    expect(counts.pending).toBe(0);
+  });
+});
+
+
+describe('isValidTransition', () => {
+  test('pending → confirmed is valid', () => {
+    expect(isValidTransition('pending', 'confirmed')).toBe(true);
+  });
+
+  test('pending → cancelled is valid', () => {
+    expect(isValidTransition('pending', 'cancelled')).toBe(true);
+  });
+
+  test('pending → ready is invalid', () => {
+    expect(isValidTransition('pending', 'ready')).toBe(false);
+  });
+
+  test('confirmed → ready is valid', () => {
+    expect(isValidTransition('confirmed', 'ready')).toBe(true);
+  });
+
+  test('confirmed → cancelled is valid', () => {
+    expect(isValidTransition('confirmed', 'cancelled')).toBe(true);
+  });
+
+  test('ready → collected is valid', () => {
+    expect(isValidTransition('ready', 'collected')).toBe(true);
+  });
+
+  test('ready → cancelled is invalid', () => {
+    expect(isValidTransition('ready', 'cancelled')).toBe(false);
+  });
+
+  test('collected → anything is invalid', () => {
+    expect(isValidTransition('collected', 'pending')).toBe(false);
+    expect(isValidTransition('collected', 'cancelled')).toBe(false);
+  });
+
+  test('cancelled → anything is invalid', () => {
+    expect(isValidTransition('cancelled', 'pending')).toBe(false);
+  });
+});
+
+
+describe('getEffectiveActionLabel', () => {
+  // Mirrors the logic in order-detail.html:
+  // if delivery was requested and status is ready → show "Mark as Dispatched"
+  // otherwise show the normal next status label
+  function getEffectiveActionLabel(status, deliveryPreference) {
+    const nextLabels = {
+      pending:   'Confirm Order',
+      confirmed: 'Mark as Ready',
+      ready:     'Mark as Collected'
+    };
+    if (deliveryPreference === 'delivery' && status === 'ready') {
+      return 'Mark as Dispatched';
+    }
+    return nextLabels[status] || null;
+  }
+
+  test('shows Mark as Dispatched when delivery requested and status is ready', () => {
+    expect(getEffectiveActionLabel('ready', 'delivery')).toBe('Mark as Dispatched');
+  });
+
+  test('shows Mark as Collected when pickup preferred and status is ready', () => {
+    expect(getEffectiveActionLabel('ready', 'pickup')).toBe('Mark as Collected');
+  });
+
+  test('shows Mark as Collected when no delivery preference set', () => {
+    expect(getEffectiveActionLabel('ready', null)).toBe('Mark as Collected');
+  });
+
+  test('shows Confirm Order for pending regardless of delivery preference', () => {
+    expect(getEffectiveActionLabel('pending', 'delivery')).toBe('Confirm Order');
+  });
+
+  test('shows Mark as Ready for confirmed regardless of delivery preference', () => {
+    expect(getEffectiveActionLabel('confirmed', 'delivery')).toBe('Mark as Ready');
+  });
+
+  test('returns null for collected status', () => {
+    expect(getEffectiveActionLabel('collected', null)).toBeNull();
+  });
+});
+
+
+describe('shouldShowDeliveryBadge', () => {
+  function shouldShowDeliveryBadge(deliveryPreference) {
+    return deliveryPreference === 'delivery';
+  }
+
+  test('shows badge when delivery is requested', () => {
+    expect(shouldShowDeliveryBadge('delivery')).toBe(true);
+  });
+
+  test('hides badge when pickup is selected', () => {
+    expect(shouldShowDeliveryBadge('pickup')).toBe(false);
+  });
+
+  test('hides badge when no preference set', () => {
+    expect(shouldShowDeliveryBadge(null)).toBe(false);
+  });
+
+  test('hides badge when preference is undefined', () => {
+    expect(shouldShowDeliveryBadge(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What's in this PR

Sprint 3 deliverables — pharmacy side fully wired and delivery preference feature added.

### Changes
- pharmacy.js — order fetching, status updates, pharmacy registration
- Pharmacy dashboard — live orders, filtering, counts, setup modal
- Pharmacy order-detail — status action buttons, save notes, delivery badge, dispatched label
- Patient request-detail — delivery preference (pickup/delivery) with 9AM–9PM restriction
- Signup simplified — pharmacy details moved to dashboard setup modal
- Input validation — email regex, password strength, name and phone validation on login/signup
- Collected/cancelled orders hidden from All tab on both dashboards
- patientName and pharmacyName now stored in request documents
- Logout fixed and consistent across all pages
- env.js loading fixed on all pages

### Testing
All tests passing — 35 auth, 24 patient, 32 pharmacy (91 total).

### Notes
- Firestore rules deployed to both sharecare-dev and sharecare-prod
- Community pages (Sprint 4) still have placeholder auth — will be wired next sprint